### PR TITLE
Fix implementation of singleton ComponentEditor instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
 * **Editor** Added to the `ComponentEditor` support for `UiSchema` to be defined with the `Component Schema`
+
+### Fix
+
+* **Editor** Fix implementation of singleton `ComponentEditor` instance that affected the test environment
 
 ## [1.4.0] - 2018-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * **Editor** Added to the `ComponentEditor` support for `UiSchema` to be defined with the `Component Schema`
 
-### Fix
+### Fixed
 
 * **Editor** Fix implementation of singleton `ComponentEditor` instance that affected the test environment
 

--- a/react/__tests__/ComponentEditor.test.js
+++ b/react/__tests__/ComponentEditor.test.js
@@ -63,6 +63,8 @@ describe('<ComponentEditor /> component', () => {
       expect(component).toBeTruthy()
       expect(component.props().children.props).toBeTruthy()
       expect(component.props().children.props.component).toBe(staticComponent)
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
     })
   
     /**  
@@ -70,27 +72,31 @@ describe('<ComponentEditor /> component', () => {
      * of instances.
      * @author Andre Abrantes - 02-MAY-2018
      */
-    // it('should be consistent to the schema definition', () => {
-    //   const { component } = renderComponent(staticComponent)
-    //   const { properties: {example} } = schema
-    //   const exampleInput = component.find('input').props()
-    //   expect(exampleInput.label).toBe(example.title)
-    //   expect(exampleInput.type).toBe('text')
-    // })
+    it('should be consistent to the schema definition', () => {
+      const { component } = renderComponent(staticComponent)
+      const { properties: {example} } = schema
+      const exampleInput = component.find('input').props()
+      expect(exampleInput.label).toBe(example.title)
+      expect(exampleInput.type).toBe('text')
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
+    })
   
-    // it('should render a number input', () => {
-    //   schema.properties = {
-    //     quantity: {
-    //       type: 'number',
-    //       title: 'Quantity'
-    //     }
-    //   }
-    //   const { component } = renderComponent(staticComponent)
-    //   const { properties: {quantity} } = schema
-    //   const quantityInput = component.find('input').props()
-    //   expect(quantityInput.label).toBe(quantity.title)
-    //   expect(quantityInput.type).toBe('number')
-    // })
+    it('should render a number input', () => {
+      schema.properties = {
+        quantity: {
+          type: 'number',
+          title: 'Quantity'
+        }
+      }
+      const { component } = renderComponent(staticComponent)
+      const { properties: {quantity} } = schema
+      const quantityInput = component.find('input').props()
+      expect(quantityInput.label).toBe(quantity.title)
+      expect(quantityInput.type).toBe('number')
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
+    })
   })
 
   describe('with dynamic schema', () => {
@@ -138,32 +144,36 @@ describe('<ComponentEditor /> component', () => {
       expect(component).toBeTruthy()
       expect(component.props().children.props).toBeTruthy()
       expect(component.props().children.props.component).toBe(dynamicComponent)
-    })
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
+    })  
     
     /**  
      * FIXME: Test commented because of the ComponentEditor singleton implementation
      * of instances.
      * @author Andre Abrantes - 02-MAY-2018
      */
-    // it('should be consistent to the schema definition', () => {
-    //   const NUMBER_OF_BANNERS = 2
-    //   const { component } = renderComponent(dynamicComponent, {numberOfBanners: NUMBER_OF_BANNERS})
-    //   const { properties } = getSchema({numberOfBanners: NUMBER_OF_BANNERS})
+    it('should be consistent to the schema definition', () => {
+      const NUMBER_OF_BANNERS = 2
+      const { component } = renderComponent(dynamicComponent, {numberOfBanners: NUMBER_OF_BANNERS})
+      const { properties } = getSchema({numberOfBanners: NUMBER_OF_BANNERS})
       
-    //   const renderedInputs = component.find('input')
+      const renderedInputs = component.find('input')
       
-    //   const NUMBER_OF_PROPERTIES = 1
+      const NUMBER_OF_PROPERTIES = 1
       
-    //   expect(renderedInputs.getElements().length).toBe(NUMBER_OF_BANNERS + NUMBER_OF_PROPERTIES)
+      expect(renderedInputs.getElements().length).toBe(NUMBER_OF_BANNERS + NUMBER_OF_PROPERTIES)
       
-    //   const numberOfProperties = renderedInputs.find({label: properties.numberOfBanners.title}).props()
-    //   expect(numberOfProperties.value).toBe(NUMBER_OF_BANNERS)
+      const numberOfProperties = renderedInputs.find({label: properties.numberOfBanners.title}).props()
+      expect(numberOfProperties.value).toBe(NUMBER_OF_BANNERS)
       
-    //   const banner1 = renderedInputs.find({id: 'root_banner1_image'}).props()
-    //   expect(banner1.label).toBe(properties.banner1.properties.image.title)
+      const banner1 = renderedInputs.find({id: 'root_banner1_image'}).props()
+      expect(banner1.label).toBe(properties.banner1.properties.image.title)
       
-    //   const banner2 = renderedInputs.find({id: 'root_banner2_image'}).props()
-    //   expect(banner2.label).toBe(properties.banner2.properties.image.title)
-    // })
+      const banner2 = renderedInputs.find({id: 'root_banner2_image'}).props()
+      expect(banner2.label).toBe(properties.banner2.properties.image.title)
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
+    })
   })
 })

--- a/react/__tests__/ComponentEditor.test.js
+++ b/react/__tests__/ComponentEditor.test.js
@@ -14,6 +14,7 @@ describe('<ComponentEditor /> component', () => {
   const staticComponent = 'static_component'  
   const dynamicComponent = 'dynamic_component'
 
+  
   /* Set up the list of components retrieved by the graphQL api */ 
   global.__RUNTIME__ = {
     components: {
@@ -25,20 +26,22 @@ describe('<ComponentEditor /> component', () => {
       ]
     }
   }
-
+  
   function renderComponent(componentName, props={}) {
     const treePath = ''
-
+    
     const component = mount(
       <MockedProvider>
         <ComponentEditor key="editor" component={componentName} props={props} treePath={treePath}/>
       </MockedProvider>
     )
-
+    
     return { component }
   }
-
+  
   describe('with static schema', () => {
+    let component
+
     const schema = {
       component: 'Carousel',
       description: 'A simple component',
@@ -57,29 +60,25 @@ describe('<ComponentEditor /> component', () => {
         [staticComponent]: { schema }
       }
     })
-  
-    it('should render the correct component', () => {
-      const { component } = renderComponent(staticComponent)
-      expect(component).toBeTruthy()
-      expect(component.props().children.props).toBeTruthy()
-      expect(component.props().children.props.component).toBe(staticComponent)
+
+    afterEach(() => {
       component.find('ComponentEditor').instance().unmountInstance()
       component.unmount()
     })
   
-    /**  
-     * FIXME: Test commented because of the ComponentEditor singleton implementation
-     * of instances.
-     * @author Andre Abrantes - 02-MAY-2018
-     */
+    it('should render the correct component', () => {
+      component = renderComponent(staticComponent).component
+      expect(component).toBeTruthy()
+      expect(component.props().children.props).toBeTruthy()
+      expect(component.props().children.props.component).toBe(staticComponent)
+    })
+
     it('should be consistent to the schema definition', () => {
-      const { component } = renderComponent(staticComponent)
+      component = renderComponent(staticComponent).component
       const { properties: {example} } = schema
       const exampleInput = component.find('input').props()
       expect(exampleInput.label).toBe(example.title)
       expect(exampleInput.type).toBe('text')
-      component.find('ComponentEditor').instance().unmountInstance()
-      component.unmount()
     })
   
     it('should render a number input', () => {
@@ -89,13 +88,11 @@ describe('<ComponentEditor /> component', () => {
           title: 'Quantity'
         }
       }
-      const { component } = renderComponent(staticComponent)
+      component = renderComponent(staticComponent).component
       const { properties: {quantity} } = schema
       const quantityInput = component.find('input').props()
       expect(quantityInput.label).toBe(quantity.title)
       expect(quantityInput.type).toBe('number')
-      component.find('ComponentEditor').instance().unmountInstance()
-      component.unmount()
     })
   })
 
@@ -131,6 +128,8 @@ describe('<ComponentEditor /> component', () => {
         }
       }
     }
+
+    let component
     
     beforeEach(() => {
       /* Set up the component, mocking the retrieve implementation from graphQL api */
@@ -139,23 +138,24 @@ describe('<ComponentEditor /> component', () => {
       }
     })
 
+    afterEach(() => {
+      component.find('ComponentEditor').instance().unmountInstance()
+      component.unmount()
+    })
+
     it('should render the correct component', () => {
-      const { component } = renderComponent(dynamicComponent)
+      component = renderComponent(dynamicComponent).component
       expect(component).toBeTruthy()
       expect(component.props().children.props).toBeTruthy()
       expect(component.props().children.props.component).toBe(dynamicComponent)
-      component.find('ComponentEditor').instance().unmountInstance()
-      component.unmount()
     })  
-    
-    /**  
-     * FIXME: Test commented because of the ComponentEditor singleton implementation
-     * of instances.
-     * @author Andre Abrantes - 02-MAY-2018
-     */
+
     it('should be consistent to the schema definition', () => {
       const NUMBER_OF_BANNERS = 2
-      const { component } = renderComponent(dynamicComponent, {numberOfBanners: NUMBER_OF_BANNERS})
+      component = renderComponent(dynamicComponent, {
+        numberOfBanners: NUMBER_OF_BANNERS
+      }).component
+
       const { properties } = getSchema({numberOfBanners: NUMBER_OF_BANNERS})
       
       const renderedInputs = component.find('input')
@@ -172,8 +172,6 @@ describe('<ComponentEditor /> component', () => {
       
       const banner2 = renderedInputs.find({id: 'root_banner2_image'}).props()
       expect(banner2.label).toBe(properties.banner2.properties.image.title)
-      component.find('ComponentEditor').instance().unmountInstance()
-      component.unmount()
     })
   })
 })

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom'
 import { compose, graphql } from 'react-apollo'
 import Form from 'react-jsonschema-form'
 import PropTypes from 'prop-types'
-import { has, hasIn, filter, find, pick, map, prop, pickBy } from 'ramda'
+import { has, find, pick, map, prop, pickBy } from 'ramda'
 
 import SaveExtension from '../queries/SaveExtension.graphql'
 import AvailableComponents from '../queries/AvailableComponents.graphql'

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -27,8 +27,6 @@ const widgets = {
   BaseInput,
 }
 
-let openInstance = null
-
 class ComponentEditor extends Component {
   static propTypes = {
     availableComponents: PropTypes.object,
@@ -44,19 +42,23 @@ class ComponentEditor extends Component {
     emitter: PropTypes.object,
   }
 
+  static openInstance = null
+
   constructor(props, context) {
     super(props, context)
-
+    
     this.state = {
       saving: false,
     }
-
+    
     this.old = JSON.stringify({
       component: props.component,
       props: this.getSchemaProps(getImplementation(props.component), props.props),
     })
   }
-
+ 
+  unmountInstance = () => ComponentEditor.openInstance = null
+  
   componentDidMount() {
     this._isMounted = true
   }
@@ -120,7 +122,7 @@ class ComponentEditor extends Component {
           saving: false,
         })
         this.context.editExtensionPoint(null)
-        openInstance = null
+        this.unmountInstance()
       })
       .catch(err => {
         this.setState({
@@ -138,7 +140,7 @@ class ComponentEditor extends Component {
     this.context.editExtensionPoint(null)
     delete this.old
     event && event.stopPropagation()
-    openInstance = null
+    this.unmountInstance()
   }
 
   isEmptyExtensionPoint = (component) =>
@@ -209,11 +211,10 @@ class ComponentEditor extends Component {
   }
 
   render() {
-    if (openInstance && openInstance !== this) {
-      console.log('another open instance: ', this.props.component)
+    if (ComponentEditor.openInstance && ComponentEditor.openInstance !== this) {
       return null
     }
-    openInstance = this
+    ComponentEditor.openInstance = this
 
     const { component, props } = this.props
     const Component = getImplementation(component)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the implementation of singleton ComponentEditor and fix tests affected by the changes.

#### How should this be manually tested?
Access: https://singleton-editor--storecomponents.myvtex.com/shelf and check that the multiple editors don't open when clicking to edit the product summary.

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
