### PR TITLE
Remove singleton ComponentEditor

### DIFF
--- a/react/__tests__/ComponentEditor.test.js
+++ b/react/__tests__/ComponentEditor.test.js
@@ -62,7 +62,6 @@ describe('<ComponentEditor /> component', () => {
     })
 
     afterEach(() => {
-      component.find('ComponentEditor').instance().unmountInstance()
       component.unmount()
     })
   
@@ -139,7 +138,6 @@ describe('<ComponentEditor /> component', () => {
     })
 
     afterEach(() => {
-      component.find('ComponentEditor').instance().unmountInstance()
       component.unmount()
     })
 

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -44,8 +44,6 @@ class ComponentEditor extends Component {
     emitter: PropTypes.object,
   }
 
-  static openInstance = null
-
   constructor(props, context) {
     super(props, context)
 
@@ -58,8 +56,6 @@ class ComponentEditor extends Component {
       props: this.getSchemaProps(getImplementation(props.component), props.props),
     })
   }
-
-  unmountInstance = () => ComponentEditor.openInstance = null
 
   componentDidMount() {
     this._isMounted = true
@@ -126,7 +122,6 @@ class ComponentEditor extends Component {
           saving: false,
         })
         this.context.editExtensionPoint(null)
-        this.unmountInstance()
       })
       .catch(err => {
         this.setState({
@@ -144,7 +139,6 @@ class ComponentEditor extends Component {
     this.context.editExtensionPoint(null)
     delete this.old
     event && event.stopPropagation()
-    this.unmountInstance()
   }
 
   isEmptyExtensionPoint = (component) =>
@@ -215,11 +209,6 @@ class ComponentEditor extends Component {
   }
 
   render() {
-    if (ComponentEditor.openInstance && ComponentEditor.openInstance !== this) {
-      return null
-    }
-    ComponentEditor.openInstance = this
-
     const { component, props } = this.props
     const Component = getImplementation(component)
     const editableComponents = this.props.availableComponents.availableComponents


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the ComponentEditor singleton implementation.

#### What problem is this solving?
Removing the singleton solves the bug when errors occur within the components and the editor can't recover, forcing the user to reload the page. But, it will expose the bug when opening the product summary editor inside the shelf component. That problem will be attacked in another moment.

#### How should this be manually tested?
Access: https://singleton-editor--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
