### PR TITLE
Support deep hierarchies in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Hide the input label when it's a checkbox.
 
+### Added
+
+- Support for deep schema objects
+
 ## [1.5.1] - 2018-05-03
 ### Fixed
 - Avoid setting everything as undefined

--- a/react/EditableExtensionPoint.js
+++ b/react/EditableExtensionPoint.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 
 import ComponentEditor from './components/ComponentEditor'
@@ -80,16 +80,18 @@ class EditableExtensionPoint extends Component {
     const editableClasses = mouseOver ? `br2 pointer ${!isEmpty ? 'b--blue b--dashed ba bg-white o-50' : ''}` : ''
     const overlayClasses = `w-100 h-100 min-h-2 z-${zIndex} absolute ${editableClasses}`
     const withOverlay = (
-      <div key="editable" className="relative" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
+      <div className="relative" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
         <div className={overlayClasses} onClick={this.handleEditClick}></div>
         {children && React.cloneElement(children, parentProps)}
       </div>
     )
 
-    return [
-      ...(editMode && !editTreePath ? [withOverlay] : [children]),
-      ...(editTreePath === treePath ? [<ComponentEditor key="editor" component={component} props={props} treePath={treePath} />] : []),
-    ]
+    return (
+      <Fragment>
+        {editMode && !editTreePath ? withOverlay : children}
+        {editTreePath === treePath && <ComponentEditor component={component} props={props} treePath={treePath} />}
+      </Fragment>
+    )
   }
 }
 

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -68,12 +68,19 @@ class ComponentEditor extends Component {
       return null
     }
 
-    const getDeepProps = (properties = {}, prevProps) =>
+    /**
+     * Recursively get the props defined in the properties.
+     *
+     * @param {object} properties The schema properties
+     * @param {object} prevProps The previous props passed to the component
+     * @return {object} Actual component props
+     */
+    const getPropsFromSchema = (properties = {}, prevProps) =>
       reduce(
         (nextProps, key) =>
           merge(nextProps, {
             [key]: properties[key].type === 'object'
-              ? getDeepProps(properties[key].properties, prevProps[key])
+              ? getPropsFromSchema(properties[key].properties, prevProps[key])
               : prevProps[key],
           }),
         {},
@@ -82,7 +89,7 @@ class ComponentEditor extends Component {
 
     const componentSchema = this.getComponentSchema(component, props)
 
-    return getDeepProps(componentSchema.properties, props)
+    return getPropsFromSchema(componentSchema.properties, props)
   }
 
   handleFormChange = (event) => {

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -70,11 +70,11 @@ class ComponentEditor extends Component {
 
     const getDeepProps = (properties = {}, prevProps) =>
       reduce(
-        (nextProps, k) =>
+        (nextProps, key) =>
           merge(nextProps, {
-            [k]: properties[k].type === 'object'
-              ? getDeepProps(properties[k].properties, prevProps[k])
-              : prevProps[k],
+            [key]: properties[key].type === 'object'
+              ? getDeepProps(properties[key].properties, prevProps[key])
+              : prevProps[key],
           }),
         {},
         filter(v => prevProps[v] !== undefined, keys(properties))

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom'
 import { compose, graphql } from 'react-apollo'
 import Form from 'react-jsonschema-form'
 import PropTypes from 'prop-types'
-import { has, find, pick, map, prop, pickBy, reduce, filter, keys, merge } from 'ramda'
+import { has, find, map, prop, pickBy, reduce, filter, keys, merge } from 'ramda'
 
 import SaveExtension from '../queries/SaveExtension.graphql'
 import AvailableComponents from '../queries/AvailableComponents.graphql'


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add support for deep nesting object definitions in the schema used by the `ComponentEditor`.

#### What problem is this solving?
The editor wasn't applying the correct props to the component when they were inside a nested object of the schema. Example:

```js
MyComponent.getSchema = ({ num }) => {
  return {
    type: 'object',
    properties: {
      num: { type: 'number' },
      numDeep: {
        type: 'object',
        properties: {
          ...R.range(0, num).map(i => ({
            [`numDeep${i}`]: { type: 'number' },
          })
        }
      }
    }
  }
};
```

In the above case, when you decremented the number of properties in the editor, the `numDeepX` properties inside `numDeep` still were passed as props to the `MyComponent`.

#### How should this be manually tested?
[Visit my workspace](https://lucas--storecomponents.myvtex.com/) and decrement the number of payment forms of the `Footer` component.

You can see in [this workspace](https://footerbug--storecomponents.myvtex.com/) the buggy behavior.

#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
