### PR TITLE
Hide the input label when it's a checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,24 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Hide the input label when it's a checkbox.
 
 ## [1.5.1] - 2018-05-03
-
 ### Fixed
-
-* Avoid setting everything as undefined
-* Fix implementation of singleton `ComponentEditor` instance that affected the test environment
+- Avoid setting everything as undefined
+- Fix implementation of singleton `ComponentEditor` instance that affected the test environment
 
 ## [1.5.0] - 2018-05-03
-
-* Added to the `ComponentEditor` support for `UiSchema` to be defined with the `Component Schema`
+- Added to the `ComponentEditor` support for `UiSchema` to be defined with the `Component Schema`
 
 ## [1.4.0] - 2018-04-24
-
 ### Added
-
-* Added to the `ComponentEditor` support for dynamic component schemas.
+- Added to the `ComponentEditor` support for dynamic component schemas.
 
 ### Fixed
-
-* Fixed the `ComponentEditor` to save extension
+- Fixed the `ComponentEditor` to save extension

--- a/react/components/form/FieldTemplate.js
+++ b/react/components/form/FieldTemplate.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 function Label(props) {
-  const { label, required, id } = props
+  const { label, required, id, type } = props
   if (!label) {
     return <div />
   }
@@ -31,6 +31,7 @@ export default function FieldTemplate(props) {
     description,
     hidden,
     required,
+    schema
   } = props
 
   if (hidden) {
@@ -39,7 +40,9 @@ export default function FieldTemplate(props) {
 
   return (
     <div className={`${classNames} w-100`}>
-      <Label label={label} required={required} id={id} />
+      {schema.type != 'boolean' && (
+        <Label label={label} required={required} id={id} />
+      )}
       {description && description}
       {children}
       {errors}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Hide the input label when it's a checkbox.

#### What problem is this solving?
The label it's duplicating the checkbox value.

#### How should this be manually tested?
Access: https://andre--storecomponents.myvtex.com

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
