### PR TITLE
Internationalization of the component schema

### DIFF
--- a/react/__tests__/ComponentEditor.test.js
+++ b/react/__tests__/ComponentEditor.test.js
@@ -1,10 +1,13 @@
 import React from 'react'
+import { IntlProvider } from 'react-intl'
 import { MockedProvider } from 'react-apollo/test-utils'
 import ComponentEditor from '../components/ComponentEditor'
 
 import { mount } from 'enzyme'
 
 import { range, map, clone, indexBy, prop } from 'ramda'
+
+process.env.NODE_ENV = 'production' // avoid react-intl warnings
 
 describe('<ComponentEditor /> component', () => {
   const staticComponent = 'static_component'
@@ -22,13 +25,19 @@ describe('<ComponentEditor /> component', () => {
     },
   }
 
+  const localeMessages = {
+    'editor.category-menu.title': 'Category Menu',
+  }
+
   function renderComponent(componentName, props = {}) {
     const treePath = ''
 
     const component = mount(
-      <MockedProvider>
-        <ComponentEditor key="editor" component={componentName} props={props} treePath={treePath} />
-      </MockedProvider>
+      <IntlProvider locale="en-US" messages={localeMessages}>
+        <MockedProvider>
+          <ComponentEditor key="editor" component={componentName} props={props} treePath={treePath} />
+        </MockedProvider>
+      </IntlProvider>
     )
 
     return { component }
@@ -63,8 +72,8 @@ describe('<ComponentEditor /> component', () => {
     it('should render the correct component', () => {
       component = renderComponent(staticComponent).component
       expect(component).toBeTruthy()
-      expect(component.props().children.props).toBeTruthy()
-      expect(component.props().children.props.component).toBe(staticComponent)
+      expect(component.props().children.props.children.props).toBeTruthy()
+      expect(component.props().children.props.children.props.component).toBe(staticComponent)
     })
 
     it('should be consistent to the schema definition', () => {
@@ -139,8 +148,8 @@ describe('<ComponentEditor /> component', () => {
     it('should render the correct component', () => {
       component = renderComponent(dynamicComponent).component
       expect(component).toBeTruthy()
-      expect(component.props().children.props).toBeTruthy()
-      expect(component.props().children.props.component).toBe(dynamicComponent)
+      expect(component.props().children.props.children.props).toBeTruthy()
+      expect(component.props().children.props.children.props.component).toBe(dynamicComponent)
     })
 
     it('should be consistent to the schema definition', () => {
@@ -165,6 +174,33 @@ describe('<ComponentEditor /> component', () => {
 
       const banner2 = renderedInputs.find({ id: 'root_banner2_image' }).props()
       expect(banner2.label).toBe(properties.banner2.properties.image.title)
+    })
+  })
+
+  describe('i18l', () => {
+    let component
+
+    const schema = {
+      title: 'editor.category-menu.title',
+      type: 'object',
+    }
+
+    beforeEach(() => {
+      global.__RENDER_7_COMPONENTS__ = {
+        [staticComponent]: {
+          schema,
+        },
+      }
+    })
+
+    afterEach(() => {
+      component.unmount()
+    })
+
+    it('should correctly translate the schema title', () => {
+      component = renderComponent(staticComponent).component
+      expect(component.containsMatchingElement(<div>Category Menu</div>)).toBe(true)
+      expect(component.containsMatchingElement(<div>editor.category-menu.title</div>)).toBe(false)
     })
   })
 })

--- a/react/__tests__/ComponentEditor.test.js
+++ b/react/__tests__/ComponentEditor.test.js
@@ -4,41 +4,36 @@ import ComponentEditor from '../components/ComponentEditor'
 
 import { mount } from 'enzyme'
 
-import { pick, range, map, clone, indexBy, prop } from 'ramda'
+import { range, map, clone, indexBy, prop } from 'ramda'
 
 describe('<ComponentEditor /> component', () => {
-  const componentMock = {}
-
-  const defaultConfiguration = {}
-
-  const staticComponent = 'static_component'  
+  const staticComponent = 'static_component'
   const dynamicComponent = 'dynamic_component'
 
-  
-  /* Set up the list of components retrieved by the graphQL api */ 
+  /* Set up the list of components retrieved by the graphQL api */
   global.__RUNTIME__ = {
     components: {
       [staticComponent]: [
-        'StaticComponent.js'
+        'StaticComponent.js',
       ],
       [dynamicComponent]: [
-        'DynamicComponent.js'
-      ]
-    }
+        'DynamicComponent.js',
+      ],
+    },
   }
-  
-  function renderComponent(componentName, props={}) {
+
+  function renderComponent(componentName, props = {}) {
     const treePath = ''
-    
+
     const component = mount(
       <MockedProvider>
-        <ComponentEditor key="editor" component={componentName} props={props} treePath={treePath}/>
+        <ComponentEditor key="editor" component={componentName} props={props} treePath={treePath} />
       </MockedProvider>
     )
-    
+
     return { component }
   }
-  
+
   describe('with static schema', () => {
     let component
 
@@ -49,22 +44,22 @@ describe('<ComponentEditor /> component', () => {
       properties: {
         example: {
           type: 'string',
-          title: 'Example Property'
-        }
-      }
+          title: 'Example Property',
+        },
+      },
     }
-    
+
     beforeEach(() => {
       /* Set up the component, mocking the retrieve implementation from graphQL api */
       global.__RENDER_7_COMPONENTS__ = {
-        [staticComponent]: { schema }
+        [staticComponent]: { schema },
       }
     })
 
     afterEach(() => {
       component.unmount()
     })
-  
+
     it('should render the correct component', () => {
       component = renderComponent(staticComponent).component
       expect(component).toBeTruthy()
@@ -74,21 +69,21 @@ describe('<ComponentEditor /> component', () => {
 
     it('should be consistent to the schema definition', () => {
       component = renderComponent(staticComponent).component
-      const { properties: {example} } = schema
+      const { properties: { example } } = schema
       const exampleInput = component.find('input').props()
       expect(exampleInput.label).toBe(example.title)
       expect(exampleInput.type).toBe('text')
     })
-  
+
     it('should render a number input', () => {
       schema.properties = {
         quantity: {
           type: 'number',
-          title: 'Quantity'
-        }
+          title: 'Quantity',
+        },
       }
       component = renderComponent(staticComponent).component
-      const { properties: {quantity} } = schema
+      const { properties: { quantity } } = schema
       const quantityInput = component.find('input').props()
       expect(quantityInput.label).toBe(quantity.title)
       expect(quantityInput.type).toBe('number')
@@ -96,7 +91,7 @@ describe('<ComponentEditor /> component', () => {
   })
 
   describe('with dynamic schema', () => {
-    const getSchema = ({numberOfBanners}) => {
+    const getSchema = ({ numberOfBanners }) => {
       const repeatBanner = (repetition) => indexBy(prop('title'), map((index) => {
         const property = clone({
           type: 'object',
@@ -106,12 +101,12 @@ describe('<ComponentEditor /> component', () => {
               type: 'string',
               title: 'Banner image',
             },
-          }
+          },
         })
         property.title = `${property.title}${index}`
         return property
-      }, range(1, repetition+1)))
-  
+      }, range(1, repetition + 1)))
+
       const generatedSchema = numberOfBanners && repeatBanner(numberOfBanners)
 
       return {
@@ -121,19 +116,19 @@ describe('<ComponentEditor /> component', () => {
         properties: {
           numberOfBanners: {
             type: 'number',
-            title: 'Number of Banners'
+            title: 'Number of Banners',
           },
-          ...generatedSchema
-        }
+          ...generatedSchema,
+        },
       }
     }
 
     let component
-    
+
     beforeEach(() => {
       /* Set up the component, mocking the retrieve implementation from graphQL api */
       global.__RENDER_7_COMPONENTS__ = {
-        [dynamicComponent]: { getSchema }
+        [dynamicComponent]: { getSchema },
       }
     })
 
@@ -146,29 +141,29 @@ describe('<ComponentEditor /> component', () => {
       expect(component).toBeTruthy()
       expect(component.props().children.props).toBeTruthy()
       expect(component.props().children.props.component).toBe(dynamicComponent)
-    })  
+    })
 
     it('should be consistent to the schema definition', () => {
       const NUMBER_OF_BANNERS = 2
       component = renderComponent(dynamicComponent, {
-        numberOfBanners: NUMBER_OF_BANNERS
+        numberOfBanners: NUMBER_OF_BANNERS,
       }).component
 
-      const { properties } = getSchema({numberOfBanners: NUMBER_OF_BANNERS})
-      
+      const { properties } = getSchema({ numberOfBanners: NUMBER_OF_BANNERS })
+
       const renderedInputs = component.find('input')
-      
+
       const NUMBER_OF_PROPERTIES = 1
-      
+
       expect(renderedInputs.getElements().length).toBe(NUMBER_OF_BANNERS + NUMBER_OF_PROPERTIES)
-      
-      const numberOfProperties = renderedInputs.find({label: properties.numberOfBanners.title}).props()
+
+      const numberOfProperties = renderedInputs.find({ label: properties.numberOfBanners.title }).props()
       expect(numberOfProperties.value).toBe(NUMBER_OF_BANNERS)
-      
-      const banner1 = renderedInputs.find({id: 'root_banner1_image'}).props()
+
+      const banner1 = renderedInputs.find({ id: 'root_banner1_image' }).props()
       expect(banner1.label).toBe(properties.banner1.properties.image.title)
-      
-      const banner2 = renderedInputs.find({id: 'root_banner2_image'}).props()
+
+      const banner2 = renderedInputs.find({ id: 'root_banner2_image' }).props()
       expect(banner2.label).toBe(properties.banner2.properties.image.title)
     })
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the internationalization to the component editor via the translation of the `title`, `description`, and every string in the `enumNames` array of the component schema, using `react-intl` and the messages provided by the own app `locales.json`.

#### What problem is this solving?
fixes #15.

#### How should this be manually tested?
[Access this workspace](https://lucas--storecomponents.myvtex.com/) and edit the category menu, change the locale to either english or portuguese and edit the component again. The two labels should change accordingly.

#### Screenshots or example usage

* Portuguese translation:

![image](https://user-images.githubusercontent.com/10223856/40975159-6153a95e-68a0-11e8-9cef-19d1afe46ce2.png)

* English translation:

![image](https://user-images.githubusercontent.com/10223856/40975084-22896542-68a0-11e8-96a4-4b24e0e824f3.png)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
