### PR TITLE
Internationalization of the component ui schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Translate `ui:placeholder`, `ui:help`, `ui:description`, and `ui:title` inside the `widget` property of the schema
 - Translate `title`, `description` and `enumNames` properties in component schema.
 
 ## [1.6.0] - 2018-05-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dynamic parameter in the translated string via object values.
+
 ### Changed
 - Translate `ui:placeholder`, `ui:help`, `ui:description`, and `ui:title` inside the `widget` property of the schema
 - Translate `title`, `description` and `enumNames` properties in component schema.

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -185,7 +185,9 @@ class ComponentEditor extends Component {
      * @return {object} Schema with title, description and enumNames properties translated
      */
     const traverseAndTranslate = schema => {
-      const translate = value => this.props.intl.formatMessage({ id: value })
+      const translate = value => typeof value === 'string'
+        ? this.props.intl.formatMessage({ id: value })
+        : this.props.intl.formatMessage({ id: value.id }, value.values || {})
 
       const translatedSchema = map(
         value => Array.isArray(value) ? map(translate, value) : translate(value),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the internationalization to some properties of the `uiSchema` of the component that is embedded with the `schema`. The translated properties were `ui:help`, `ui:title`, `ui:description` and `ui:placeholder`.

This also add the possibility of using the dynamic parameter injection to the `formatMessage` function of `react-intl`, all you need to do is instead of writing a simple string with the id of the message you put an object like so

```js
const schema = {
  title: { id: 'foo.bar', values: { name: 'baz' }},
}
```

This is interesting when you are creating a dynamic schema based on the `getSchema` function, and need to render something like a list and want your properties titles to be indexed.

#### What problem is this solving?
fixes #24.

#### How should this be manually tested?
[Access this workspace](https://lucas--storecomponents.myvtex.com/) and edit the carousel component in either english or portuguese.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
