### PR TITLE
Fix/bug z index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bug of z-index in the EditableExtensionPoint when the treePath has many resources.
 
 ## [1.7.0] - 2018-6-6
 ### Added

--- a/react/EditableExtensionPoint.js
+++ b/react/EditableExtensionPoint.js
@@ -78,10 +78,10 @@ class EditableExtensionPoint extends Component {
     const isEmpty = this.isEmptyExtensionPoint(component)
     const zIndex = treePath.split('/').length + 1
     const editableClasses = mouseOver ? `br2 pointer ${!isEmpty ? 'b--blue b--dashed ba bg-white o-50' : ''}` : ''
-    const overlayClasses = `w-100 h-100 min-h-2 z-${zIndex} absolute ${editableClasses}`
+    const overlayClasses = `w-100 h-100 min-h-2 absolute ${editableClasses}`
     const withOverlay = (
       <div className="relative" onMouseOver={this.handleMouseOver} onMouseOut={this.handleMouseOut}>
-        <div className={overlayClasses} onClick={this.handleEditClick}></div>
+        <div className={overlayClasses} onClick={this.handleEditClick} style={{ zIndex }}></div>
         {children && React.cloneElement(children, parentProps)}
       </div>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix z-index bug in the EditableExtensionPoint when the treePath has many resources.

#### What problem is this solving?
The tachyons classes only go up to z-5.

#### How should this be manually tested?
[Workspace Link](https://claudivan--storecomponents.myvtex.com/Eletronics/Smartphones/s?map=c,c&page=1&O=OrderByTopSaleDESC)

#### Screenshots or example usage

![screenshot from 2018-06-07 10-32-21](https://user-images.githubusercontent.com/4960686/41105574-61716c46-6a44-11e8-9295-ec9bb07fc13e.png)

![screenshot from 2018-06-07 11-17-59](https://user-images.githubusercontent.com/4960686/41105616-7bbd3df0-6a44-11e8-863f-6581746358eb.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
