### PR TITLE
Feature - Styleguide components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.0] - 2018-6-12
 ### Added
 - Create wrappers for Styleguide components and replace some of RJSF's default widgets with them;
 - Create custom `ErrorListTemplate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Create wrappers for Styleguide components and replace some of RJSF's default widgets with them;
+- Create custom `ErrorListTemplate`.
+
+### Changed
+- Restructure label logic;
+- Move `ComponentEditor`'s top bar and buttons out of form;
+- Make `ComponentEditor`'s close icon a button;
+- Refactor `BaseInput`;
+- Move error messages and handling to widgets.
+
+### Fixed
+- Fix `ComponentEditor`'s internal z-index;
+- Fix `FieldTemplate`'s description logic;
+- Fix `BaseInput`'s `onChange` edge case bug.
 
 ## [1.7.1] - 2018-6-11
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "react": "2.x"
   },
   "dependencies": {
-    "vtex.pages-graphql": "1.x"
+    "vtex.pages-graphql": "1.x",
+    "vtex.styleguide": "4.x"
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pages-editor",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "title": "VTEX Pages Editor",
   "description": "The VTEX Pages framework editor components",
   "builders": {

--- a/react/PageList.js
+++ b/react/PageList.js
@@ -65,7 +65,7 @@ class PageList extends Component {
           <h1>My Pages</h1>
           <div>
             <Link to="pages/page/new">
-              <Button primary>New page</Button>
+              <Button size="small" variation="primary">New page</Button>
             </Link>
           </div>
         </div>

--- a/react/PageList.js
+++ b/react/PageList.js
@@ -1,11 +1,11 @@
-import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import {graphql} from 'react-apollo'
-import PagesQuery from './queries/Pages.graphql'
+import React, { Component } from 'react'
+import { graphql } from 'react-apollo'
+import { Link } from 'render'
+import { Button } from 'vtex.styleguide'
 
-import {Link} from 'render'
-import Button from '@vtex/styleguide/lib/Button'
 import ShareIcon from './images/ShareIcon'
+import PagesQuery from './queries/Pages.graphql'
 
 // eslint-disable-next-line
 class PageList extends Component {

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -15,6 +15,7 @@ import BaseInput from './form/BaseInput'
 import Dropdown from './form/Dropdown'
 import FieldTemplate from './form/FieldTemplate'
 import ObjectFieldTemplate from './form/ObjectFieldTemplate'
+import Radio from './form/Radio'
 import Toggle from './form/Toggle'
 
 import Draggable from 'react-draggable'
@@ -29,6 +30,7 @@ const defaultUiSchema = {
 const widgets = {
   BaseInput,
   CheckboxWidget: Toggle,
+  RadioWidget: Radio,
   SelectWidget: Dropdown,
 }
 

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -338,7 +338,7 @@ class ComponentEditor extends Component {
                 widgets={widgets}>
                 <div className="flex fixed bottom-0 w-100 bt bw2 b--light-silver">
                   <div className="w-50 tc br b--light-silver bw2 h-100 bg-near-white pointer hover-bg-light-silver hover-heavy-blue lh-copy">
-                    <Button block size="large" onClick={this.handleCancel}>
+                    <Button variation="tertiary" block size="regular" onClick={this.handleCancel}>
                       Cancel
                     </Button>
                   </div>
@@ -346,7 +346,7 @@ class ComponentEditor extends Component {
                     {this.state.saving ? (
                       <Spinner size={28} />
                     ) : (
-                      <Button block size="large" type="submit">
+                      <Button variation="tertiary" block size="regular" type="submit">
                           Save
                       </Button>
                     )}

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -317,8 +317,8 @@ class ComponentEditor extends Component {
     const editor = (
       <div className="w-100 near-black">
         <Draggable handle=".draggable">
-          <div className={`br2-ns fixed z-max bg-white shadow-editor-desktop size-editor w-100 top-2-ns right-2-ns mt9-ns mh5-ns move animated ${animation} ${this._isMounted ? '' : 'fadeIn'}`} style={{ animationDuration: '0.2s' }}>
-            <div className="bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 fixed flex justify-between br2-ns br--top-ns draggable z-max">
+          <div className={`br2-ns fixed z-max bg-white flex flex-column shadow-editor-desktop size-editor w-100 top-2-ns right-2-ns mt9-ns mh5-ns move animated ${animation} ${this._isMounted ? '' : 'fadeIn'}`} style={{ animationDuration: '0.2s' }} >
+            <div className="bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 flex justify-between br2-ns br--top-ns draggable z-max">
               <div>
                 {displayName}
               </div>
@@ -326,7 +326,7 @@ class ComponentEditor extends Component {
                 <CloseIcon />
               </div>
             </div>
-            <div className="overflow-scroll form-schema">
+            <div className="flex-auto overflow-y-scroll form-schema">
               <Form
                 schema={schema}
                 formData={extensionProps}
@@ -335,25 +335,32 @@ class ComponentEditor extends Component {
                 FieldTemplate={FieldTemplate}
                 ObjectFieldTemplate={ObjectFieldTemplate}
                 uiSchema={uiSchema}
-                widgets={widgets}>
-                <div className="flex fixed bottom-0 w-100 bt bw2 b--light-silver">
-                  <div className="w-50 tc br b--light-silver bw2 h-100 bg-near-white pointer hover-bg-light-silver hover-heavy-blue lh-copy">
-                    <Button variation="tertiary" block size="regular" onClick={this.handleCancel}>
+                widgets={widgets}
+              >
+                <button className="dn" type="submit" />
+              </Form>
+            </div>
+            <div className="flex static-ns w-100 bt bw2 b--light-silver">
+              <div className="w-50 flex items-center justify-center bg-near-white hover-bg-light-silver hover-heavy-blue br bw2 b--light-silver">
+                <Button
+                  block
+                  onClick={this.handleCancel}
+                  size="regular"
+                  variation="tertiary"
+                >
                       Cancel
                     </Button>
                   </div>
-                  <div className="w-50 tc bg-near-white hover-bg-light-silver pointer hover-heavy-blue flex items-center justify-center">
+              <div className="w-50 flex items-center justify-center bg-near-white hover-bg-light-silver hover-heavy-blue">
                     {this.state.saving ? (
                       <Spinner size={28} />
                     ) : (
-                      <Button variation="tertiary" block size="regular" type="submit">
+                    <Button block onClick={this.handleSave} size="regular" variation="tertiary">
                           Save
                       </Button>
                     )}
                   </div>
                 </div>
-              </Form>
-            </div>
           </div>
         </Draggable>
       </div>

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -352,19 +352,19 @@ class ComponentEditor extends Component {
                   size="regular"
                   variation="tertiary"
                 >
-                      Cancel
-                    </Button>
-                  </div>
+                  Cancel
+                </Button>
+              </div>
               <div className="w-50 flex items-center justify-center bg-near-white hover-bg-light-silver hover-heavy-blue">
-                    {this.state.saving ? (
-                      <Spinner size={28} />
-                    ) : (
-                    <Button block onClick={this.handleSave} size="regular" variation="tertiary">
-                          Save
-                      </Button>
-                    )}
-                  </div>
-                </div>
+                {this.state.saving ? (
+                  <Spinner size={28} />
+                ) : (
+                  <Button block onClick={this.handleSave} size="regular" variation="tertiary">
+                    Save
+                  </Button>
+                )}
+              </div>
+            </div>
           </div>
         </Draggable>
       </div>

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -322,9 +322,9 @@ class ComponentEditor extends Component {
               <div>
                 {displayName}
               </div>
-              <div onClick={this.handleCancel} className="flex items-center pointer dim">
+              <button onClick={this.handleCancel} className="flex items-center pointer dim bg-transparent bn">
                 <CloseIcon />
-              </div>
+              </button>
             </div>
             <div className="flex-auto overflow-y-scroll form-schema">
               <Form

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -12,6 +12,7 @@ import AvailableComponents from '../queries/AvailableComponents.graphql'
 import { getImplementation } from '../utils/components'
 
 import BaseInput from './form/BaseInput'
+import Dropdown from './form/Dropdown'
 import FieldTemplate from './form/FieldTemplate'
 import ObjectFieldTemplate from './form/ObjectFieldTemplate'
 
@@ -26,6 +27,7 @@ const defaultUiSchema = {
 
 const widgets = {
   BaseInput,
+  SelectWidget: Dropdown,
 }
 
 class ComponentEditor extends Component {

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -1,4 +1,3 @@
-import Button from '@vtex/styleguide/lib/Button'
 import React, { Component } from 'react'
 import { createPortal } from 'react-dom'
 import { compose, graphql } from 'react-apollo'
@@ -6,6 +5,7 @@ import { injectIntl, intlShape } from 'react-intl'
 import Form from 'react-jsonschema-form'
 import PropTypes from 'prop-types'
 import { has, find, map, prop, pick, pickBy, reduce, filter, keys, merge } from 'ramda'
+import { Button, Spinner } from 'vtex.styleguide'
 
 import SaveExtension from '../queries/SaveExtension.graphql'
 import AvailableComponents from '../queries/AvailableComponents.graphql'
@@ -20,8 +20,6 @@ import Toggle from './form/Toggle'
 
 import Draggable from 'react-draggable'
 import CloseIcon from '../images/CloseIcon.js'
-
-import Spinner from '@vtex/styleguide/lib/Spinner'
 
 const defaultUiSchema = {
   'classNames': 'editor-form',

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -318,7 +318,7 @@ class ComponentEditor extends Component {
       <div className="w-100 near-black">
         <Draggable handle=".draggable">
           <div className={`br2-ns fixed z-max bg-white shadow-editor-desktop size-editor w-100 top-2-ns right-2-ns mt9-ns mh5-ns move animated ${animation} ${this._isMounted ? '' : 'fadeIn'}`} style={{ animationDuration: '0.2s' }}>
-            <div className="bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 fixed flex justify-between br2-ns br--top-ns draggable">
+            <div className="bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 fixed flex justify-between br2-ns br--top-ns draggable z-max">
               <div>
                 {displayName}
               </div>

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -15,6 +15,7 @@ import BaseInput from './form/BaseInput'
 import Dropdown from './form/Dropdown'
 import FieldTemplate from './form/FieldTemplate'
 import ObjectFieldTemplate from './form/ObjectFieldTemplate'
+import Toggle from './form/Toggle'
 
 import Draggable from 'react-draggable'
 import CloseIcon from '../images/CloseIcon.js'
@@ -27,6 +28,7 @@ const defaultUiSchema = {
 
 const widgets = {
   BaseInput,
+  CheckboxWidget: Toggle,
   SelectWidget: Dropdown,
 }
 

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -13,6 +13,7 @@ import { getImplementation } from '../utils/components'
 
 import BaseInput from './form/BaseInput'
 import Dropdown from './form/Dropdown'
+import ErrorListTemplate from './form/ErrorListTemplate'
 import FieldTemplate from './form/FieldTemplate'
 import ObjectFieldTemplate from './form/ObjectFieldTemplate'
 import Radio from './form/Radio'
@@ -326,6 +327,7 @@ class ComponentEditor extends Component {
                 <CloseIcon />
               </button>
             </div>
+            <div id="form__error-list-template___alert" />
             <div className="flex-auto overflow-y-scroll form-schema">
               <Form
                 schema={schema}
@@ -336,6 +338,8 @@ class ComponentEditor extends Component {
                 ObjectFieldTemplate={ObjectFieldTemplate}
                 uiSchema={uiSchema}
                 widgets={widgets}
+                showErrorList={true}
+                ErrorList={ErrorListTemplate}
               >
                 <button className="dn" type="submit" />
               </Form>

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -344,7 +344,7 @@ class ComponentEditor extends Component {
                 <button className="dn" type="submit" />
               </Form>
             </div>
-            <div className="flex static-ns w-100 bt bw2 b--light-silver">
+            <div className="flex w-100 bt bw2 b--light-silver">
               <div className="w-50 flex items-center justify-center bg-near-white hover-bg-light-silver hover-heavy-blue br bw2 b--light-silver">
                 <Button
                   block

--- a/react/components/EditBar.js
+++ b/react/components/EditBar.js
@@ -54,7 +54,7 @@ export default class EditBar extends Component {
             </div>
           </div>
           <div className="h-3em nr5 bl b--light-silver bw1 flex items-center pr4">
-            <Button onClick={this.handleClick}>
+            <Button size="small" variation="tertiary" onClick={this.handleClick}>
               <div className="flex items-center">
                 DONE
                 <div className="pl4">

--- a/react/components/EditBar.js
+++ b/react/components/EditBar.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { Button } from 'vtex.styleguide'
+
 import PageIcon from '../images/PageIcon.js'
 import CheckIcon from '../images/check-2.js'
-
-import Button from '@vtex/styleguide/lib/Button'
 
 import '../editbar.global.css'
 

--- a/react/components/PageEditor.js
+++ b/react/components/PageEditor.js
@@ -1,9 +1,9 @@
-import Button from '@vtex/styleguide/lib/Button'
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { graphql } from 'react-apollo'
 import Form from 'react-jsonschema-form'
-import PropTypes from 'prop-types'
 import { Link } from 'render'
+import { Button } from 'vtex.styleguide'
 
 import SavePage from '../queries/SavePage.graphql'
 import Pages from '../queries/Pages.graphql'

--- a/react/components/PageEditor.js
+++ b/react/components/PageEditor.js
@@ -126,11 +126,15 @@ class PageEditor extends Component {
           ObjectFieldTemplate={ObjectFieldTemplate}
           widgets={widgets}>
           <div className="mt7">
-            <Button type="submit" className="fw5 ph5 pv3 ttu br2 fw4 f7 bw1 ba b--blue bg-blue white hover-bg-heavy-blue hover-b--heavy-blue pointer mr5" primary>
+            <Button
+              size="small"
+              type="submit"
+              className="fw5 ph5 pv3 ttu br2 fw4 f7 bw1 ba b--blue bg-blue white hover-bg-heavy-blue hover-b--heavy-blue pointer mr5"
+              variation="primary">
               Salvar
             </Button>
             <Link to="/admin/pages">
-              <Button>
+              <Button size="small" variation="tertiary">
                 Cancelar
               </Button>
             </Link>

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Input from '@vtex/styleguide/lib/Input'
 
 function BaseInput(props) {
   const {
@@ -10,6 +11,7 @@ function BaseInput(props) {
     onBlur,
     onFocus,
     options,
+    required,
     schema,
     ...inputProps
   } = props
@@ -26,18 +28,22 @@ function BaseInput(props) {
   delete cleanProps.schema
   delete cleanProps.formContext
 
-  return (
-    <input
-      className="form-control w-100 br2 ba b--light-gray pa2"
-      readOnly={readonly}
-      disabled={disabled}
-      autoFocus={autofocus}
-      value={value == null ? '' : value}
-      {...cleanProps}
-      onChange={_onChange}
-      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
-      onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
-    />
+  const commonProps = {
+    ...cleanProps,
+    autoFocus: autofocus,
+    disabled,
+    onBlur: onBlur && (event => onBlur(inputProps.id, event.target.value)),
+    onChange: _onChange,
+    onFocus: onFocus && (event => onFocus(inputProps.id, event.target.value)),
+    readOnly: readonly,
+    required,
+    value: value || '',
+  }
+
+  return type === 'text' ? (
+    <Input {...commonProps} label="" />
+  ) : (
+    <input {...commonProps} />
   )
 }
 

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -11,6 +11,7 @@ const BaseInput = props => {
     onBlur,
     onFocus,
     options,
+    rawErrors,
     readonly,
     required,
     schema,
@@ -21,6 +22,8 @@ const BaseInput = props => {
 
   const type = options.inputType || props.type || schemaType
 
+  const currentError = rawErrors[0]
+
   const _onChange = ({ target: { value } }) =>
     props.onChange(value || '')
 
@@ -28,6 +31,8 @@ const BaseInput = props => {
     <Input
       autoFocus={autofocus}
       disabled={disabled}
+      error={!!currentError}
+      errorMessage={currentError}
       helpText={schema.description}
       label={label}
       onBlur={onBlur && (event => onBlur(id, event.target.value))}
@@ -44,6 +49,7 @@ const BaseInput = props => {
 BaseInput.defaultProps = {
   autofocus: false,
   disabled: false,
+  rawErrors: [],
   readonly: false,
   required: false,
 }
@@ -58,6 +64,7 @@ BaseInput.propTypes = {
   onFocus: PropTypes.func,
   options: PropTypes.object,
   placeholder: PropTypes.string,
+  rawErrors: PropTypes.arrayOf(PropTypes.string),
   readonly: PropTypes.bool,
   required: PropTypes.bool,
   schema: PropTypes.object.isRequired,

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Input from '@vtex/styleguide/lib/Input'
+import { Input } from 'vtex.styleguide'
 
 function BaseInput(props) {
   const {

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -2,70 +2,67 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Input } from 'vtex.styleguide'
 
-function BaseInput(props) {
+const BaseInput = props => {
   const {
-    value,
-    readonly,
-    disabled,
     autofocus,
+    disabled,
+    id,
     label,
     onBlur,
     onFocus,
     options,
+    readonly,
     required,
     schema,
-    ...inputProps
+    value,
   } = props
 
-  const type = schema.type === 'number' ? 'number' : 'text'
+  const schemaType = schema.type === 'number' ? 'number' : 'text'
 
-  inputProps.type = options.inputType || inputProps.type || type
-  const _onChange = ({ target: { value } }) => {
-    return props.onChange(value === '' ? options.emptyValue : value)
-  }
+  const type = options.inputType || props.type || schemaType
 
-  const { ...cleanProps } = inputProps
-  delete cleanProps.rawErrors
-  delete cleanProps.formContext
+  const _onChange = ({ target: { value } }) =>
+    props.onChange(value || '')
 
   return (
     <Input
-      {...cleanProps}
       autoFocus={autofocus}
       disabled={disabled}
       helpText={schema.description}
       label={label}
-      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
+      onBlur={onBlur && (event => onBlur(id, event.target.value))}
       onChange={_onChange}
-      onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
+      onFocus={onFocus && (event => onFocus(id, event.target.value))}
       readOnly={readonly}
       required={required}
-      value={value || ''}
+      type={type}
+      value={value}
     />
   )
 }
 
 BaseInput.defaultProps = {
-  required: false,
+  autofocus: false,
   disabled: false,
   readonly: false,
-  autofocus: false,
+  required: false,
 }
 
 BaseInput.propTypes = {
-  id: PropTypes.string.isRequired,
-  placeholder: PropTypes.string,
-  value: PropTypes.any,
-  options: PropTypes.object,
-  required: PropTypes.bool,
-  disabled: PropTypes.bool,
-  readonly: PropTypes.bool,
   autofocus: PropTypes.bool,
-  onChange: PropTypes.func,
-  onBlur: PropTypes.func,
-  onFocus: PropTypes.func,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  onFocus: PropTypes.func,
+  options: PropTypes.object,
+  placeholder: PropTypes.string,
+  readonly: PropTypes.bool,
+  required: PropTypes.bool,
   schema: PropTypes.object.isRequired,
+  type: PropTypes.string,
+  value: PropTypes.any,
 }
 
 export default BaseInput

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -28,22 +28,19 @@ function BaseInput(props) {
   delete cleanProps.schema
   delete cleanProps.formContext
 
-  const commonProps = {
-    ...cleanProps,
-    autoFocus: autofocus,
-    disabled,
-    onBlur: onBlur && (event => onBlur(inputProps.id, event.target.value)),
-    onChange: _onChange,
-    onFocus: onFocus && (event => onFocus(inputProps.id, event.target.value)),
-    readOnly: readonly,
-    required,
-    value: value || '',
-  }
-
-  return type === 'text' ? (
-    <Input {...commonProps} label="" />
-  ) : (
-    <input {...commonProps} />
+  return (
+    <Input
+      {...cleanProps}
+      autoFocus={autofocus}
+      disabled={disabled}
+      label=""
+      onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
+      onChange={_onChange}
+      onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
+      readOnly={readonly}
+      required={required}
+      value={value || ''}
+    />
   )
 }
 

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -8,6 +8,7 @@ function BaseInput(props) {
     readonly,
     disabled,
     autofocus,
+    label,
     onBlur,
     onFocus,
     options,
@@ -25,7 +26,6 @@ function BaseInput(props) {
 
   const { ...cleanProps } = inputProps
   delete cleanProps.rawErrors
-  delete cleanProps.schema
   delete cleanProps.formContext
 
   return (
@@ -33,7 +33,8 @@ function BaseInput(props) {
       {...cleanProps}
       autoFocus={autofocus}
       disabled={disabled}
-      label=""
+      helpText={schema.description}
+      label={label}
       onBlur={onBlur && (event => onBlur(inputProps.id, event.target.value))}
       onChange={_onChange}
       onFocus={onFocus && (event => onFocus(inputProps.id, event.target.value))}
@@ -63,6 +64,8 @@ BaseInput.propTypes = {
   onChange: PropTypes.func,
   onBlur: PropTypes.func,
   onFocus: PropTypes.func,
+  label: PropTypes.string.isRequired,
+  schema: PropTypes.object.isRequired,
 }
 
 export default BaseInput

--- a/react/components/form/Dropdown.js
+++ b/react/components/form/Dropdown.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import StyleguideDropdown from '@vtex/styleguide/lib/Dropdown'
+import { Dropdown as StyleguideDropdown } from 'vtex.styleguide'
 
 const getChangeHandler = (onChange, emptyValue) => ({ target: { value } }) =>
   onChange(!value ? emptyValue : value)

--- a/react/components/form/Dropdown.js
+++ b/react/components/form/Dropdown.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import StyleguideDropdown from '@vtex/styleguide/lib/Dropdown'
+
+const getChangeHandler = (onChange, emptyValue) => ({ target: { value } }) =>
+  onChange(!value ? emptyValue : value)
+
+const Dropdown = ({
+  autofocus,
+  disabled,
+  id,
+  onChange,
+  onClose,
+  onOpen,
+  options,
+  placeholder,
+  readonly,
+  value,
+}) => {
+  return (
+    <StyleguideDropdown
+      autoFocus={autofocus}
+      disabled={disabled}
+      id={id}
+      label=""
+      onChange={onChange && getChangeHandler(onChange, options.emptyValue)}
+      onClose={onClose}
+      onOpen={onOpen}
+      options={options.enumOptions}
+      placeholder={placeholder}
+      readOnly={readonly}
+      value={value || ''}
+    />
+  )
+}
+
+Dropdown.defaultProps = {
+  autofocus: false,
+  disabled: false,
+  readonly: false,
+  required: false,
+}
+
+Dropdown.propTypes = {
+  autofocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  onClose: PropTypes.func,
+  onOpen: PropTypes.func,
+  options: PropTypes.object,
+  readonly: PropTypes.bool,
+  required: PropTypes.bool,
+  value: PropTypes.any,
+}
+
+export default Dropdown

--- a/react/components/form/Dropdown.js
+++ b/react/components/form/Dropdown.js
@@ -9,6 +9,7 @@ const Dropdown = ({
   autofocus,
   disabled,
   id,
+  label,
   onChange,
   onClose,
   onOpen,
@@ -16,23 +17,21 @@ const Dropdown = ({
   placeholder,
   readonly,
   value,
-}) => {
-  return (
-    <StyleguideDropdown
-      autoFocus={autofocus}
-      disabled={disabled}
-      id={id}
-      label=""
-      onChange={onChange && getChangeHandler(onChange, options.emptyValue)}
-      onClose={onClose}
-      onOpen={onOpen}
-      options={options.enumOptions}
-      placeholder={placeholder}
-      readOnly={readonly}
-      value={value || ''}
-    />
-  )
-}
+}) => (
+  <StyleguideDropdown
+    autoFocus={autofocus}
+    disabled={disabled}
+    id={id}
+    label={label}
+    onChange={onChange && getChangeHandler(onChange, options.emptyValue)}
+    onClose={onClose}
+    onOpen={onOpen}
+    options={options.enumOptions}
+    placeholder={placeholder}
+    readOnly={readonly}
+    value={value || ''}
+  />
+)
 
 Dropdown.defaultProps = {
   autofocus: false,
@@ -45,6 +44,7 @@ Dropdown.propTypes = {
   autofocus: PropTypes.bool,
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,

--- a/react/components/form/ErrorListTemplate.js
+++ b/react/components/form/ErrorListTemplate.js
@@ -1,0 +1,79 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { createPortal } from 'react-dom'
+import { Alert } from 'vtex.styleguide'
+
+class ErrorListTemplate extends Component {
+  constructor() {
+    super()
+
+    this.state = {
+      isVisible: true,
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { errors: prevErrors } = prevProps
+    const { errors: currErrors } = this.props
+    const { isVisible } = this.state
+
+    const haveErrorsChanged =
+      currErrors.length !== prevErrors.length ||
+      (currErrors.length > 0 &&
+        currErrors.reduce(
+          (acc, error, index) => error.stack !== prevErrors[index].stack || acc,
+          false,
+        )
+      )
+
+    if (!isVisible && haveErrorsChanged) {
+      this.setState({ isVisible: true })
+    }
+  }
+
+  getErrorMessage(error) {
+    const { message, property } = error
+
+    return `${this.getFormattedFieldName(property)} ${message}`
+  }
+
+  getFormattedFieldName(fieldName) {
+    return (
+      fieldName.charAt(1).toUpperCase() +
+      fieldName.slice(2).replace(/([a-z])([A-Z])/g, '$1 $2')
+    )
+  }
+
+  handleHide = () => {
+    this.setState({ isVisible: false })
+  }
+
+  render() {
+    const { errors } = this.props
+    const { isVisible } = this.state
+
+    return createPortal(
+      errors.length > 0 &&
+      isVisible && (
+        <div className="w-100 z-max">
+          <Alert onClose={this.handleHide} type="error">
+            {errors.length > 1
+              ? `There are ${errors.length} invalid inputs.`
+              : this.getErrorMessage(errors[0])}
+          </Alert>
+        </div>
+      ),
+      document.getElementById('form__error-list-template___alert')
+    )
+  }
+}
+
+ErrorListTemplate.defaultProps = {
+  errors: [],
+}
+
+ErrorListTemplate.propTypes = {
+  errors: PropTypes.arrayOf(PropTypes.object),
+}
+
+export default ErrorListTemplate

--- a/react/components/form/FieldTemplate.js
+++ b/react/components/form/FieldTemplate.js
@@ -41,6 +41,7 @@ export default function FieldTemplate(props) {
   return (
     <div className={`${classNames} w-100`}>
       {schema.type === 'object' && <Label label={label} required={required} id={id} />}
+      {schema.type === 'object' && description}
       {children}
       {errors}
       {help}

--- a/react/components/form/FieldTemplate.js
+++ b/react/components/form/FieldTemplate.js
@@ -40,10 +40,7 @@ export default function FieldTemplate(props) {
 
   return (
     <div className={`${classNames} w-100`}>
-      {schema.type != 'boolean' && (
-        <Label label={label} required={required} id={id} />
-      )}
-      {description && description}
+      {schema.type === 'object' && <Label label={label} required={required} id={id} />}
       {children}
       {errors}
       {help}

--- a/react/components/form/FieldTemplate.js
+++ b/react/components/form/FieldTemplate.js
@@ -31,7 +31,8 @@ export default function FieldTemplate(props) {
     description,
     hidden,
     required,
-    schema
+    schema,
+    rawErrors,
   } = props
 
   if (hidden) {
@@ -43,7 +44,6 @@ export default function FieldTemplate(props) {
       {schema.type === 'object' && <Label label={label} required={required} id={id} />}
       {schema.type === 'object' && description}
       {children}
-      {errors}
       {help}
     </div>
   )
@@ -60,4 +60,5 @@ FieldTemplate.propTypes = {
   children: PropTypes.element,
   displayLabel: PropTypes.bool,
   hidden: PropTypes.bool,
+  rawErrors: PropTypes.arrayOf(PropTypes.string),
 }

--- a/react/components/form/Radio.js
+++ b/react/components/form/Radio.js
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types'
+import React, { Component, Fragment } from 'react'
+import StyleguideRadio from '@vtex/styleguide/lib/Radio'
+
+class Radio extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      value: props.value || null,
+    }
+  }
+
+  handleSelection = (event, value) => {
+    event.stopPropagation()
+
+    this.setState({ value })
+
+    this.props.onChange(value)
+  }
+
+  render() {
+    const { id, label, name, schema } = this.props
+
+    return (
+      <Fragment>
+        <span className="dib mb3 w-100">{label}</span>
+        {schema.enum &&
+          schema.enum.map((item, index) => (
+            <StyleguideRadio
+              checked={this.state.value === item}
+              id={`${id}-${index}`}
+              key={`${id}-${index}`}
+              label={item && item.toString()}
+              name={name || `${id}-group`}
+              onChange={event => this.handleSelection(event, item)}
+              value={item}
+            />
+          ))}
+      </Fragment>
+    )
+  }
+}
+
+Radio.propTypes = {
+  id: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  name: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  schema: PropTypes.object.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+}
+
+export default Radio

--- a/react/components/form/Radio.js
+++ b/react/components/form/Radio.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { Component, Fragment } from 'react'
-import StyleguideRadio from '@vtex/styleguide/lib/Radio'
+import { Radio as StyleguideRadio } from 'vtex.styleguide'
 
 class Radio extends Component {
   constructor(props) {

--- a/react/components/form/Toggle.js
+++ b/react/components/form/Toggle.js
@@ -19,6 +19,7 @@ const Toggle = ({
     id={id}
     label={label}
     onChange={event => onChange(event.target.checked)}
+    size="small"
   />
 )
 

--- a/react/components/form/Toggle.js
+++ b/react/components/form/Toggle.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import StyleguideToggle from '@vtex/styleguide/lib/Toggle'
+
+const Toggle = ({
+  autofocus,
+  disabled,
+  id,
+  label,
+  onChange,
+  options,
+  readonly,
+  value,
+}) => (
+  <StyleguideToggle
+    autoFocus={autofocus}
+    checked={value}
+    disabled={disabled || readonly}
+    id={id}
+    label={label}
+    onChange={event => onChange(event.target.checked)}
+  />
+)
+
+Toggle.defaultProps = {
+  autofocus: false,
+  disabled: false,
+  readonly: false,
+}
+
+Toggle.propTypes = {
+  autofocus: PropTypes.bool,
+  disabled: PropTypes.bool,
+  id: PropTypes.string.isRequired,
+  onChange: PropTypes.func,
+  options: PropTypes.object,
+  readonly: PropTypes.bool,
+  value: PropTypes.bool,
+}
+
+export default Toggle

--- a/react/components/form/Toggle.js
+++ b/react/components/form/Toggle.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import StyleguideToggle from '@vtex/styleguide/lib/Toggle'
+import { Toggle as StyleguideToggle } from 'vtex.styleguide'
 
 const Toggle = ({
   autofocus,

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -80,13 +80,6 @@ html, body {
   background-color: #FFFFFF;
 }
 
-.form-schema {
-  min-height: 300px;
-  max-height: 100vh;
-  padding-bottom: 66px;
-  padding-top: 62px;
-}
-
 .draggable {
   cursor: move;
 }
@@ -190,7 +183,7 @@ html, body {
   }
   .form-schema {
     min-height: 300px;
-    max-height: 80vh;
+    max-height: 60vh;
   }
   .render-container {
     padding-top: 48px;
@@ -202,5 +195,8 @@ html, body {
     -webkit-box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
     -moz-box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
     box-shadow: 0px 4px 10px 0px rgba(86,88,107,0.5);
+  }
+  .pages-editor {
+    max-height: 70vh;
   }
 }

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -41,11 +41,6 @@ html, body {
   padding-bottom: 10px;
 }
 
-.form-group label {
-  padding: 0px 0px 10px 0px;
-  color: #141E2C;
-}
-
 .form-group.field.field-object > label {
   color: #C3C4C5;
   text-transform: uppercase;

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -110,42 +110,9 @@ html, body {
   height: 46px !important;
 }
 
-.errors {
-  padding: 16px 24px 11px;
-  background-color: #FFE6E6;
-}
-
-.errors h3 {
-  margin: 0px;
-  font-size: 16px;
-}
-
-.errors ul {
-  list-style: none;
-  padding: 10px 0px 0px 0px;
-  margin: 0px;
-  font-size: 14px;
-}
-
-.errors li {
-  padding: 0px 0px 5px 0px;
-}
-
-.error-detail {
-  list-style: none;
-  padding: 0px 0px 0px 0px;
-  margin: 0px;
-  font-size: 14px;
-  color: #FF4C4C;
-}
-
 .radio-inline > span > span {
   padding-left: 5px;
   padding-right: 15px;
-}
-
-.has-error input {
-  border: 2px solid #FF4C4C;
 }
 
 .field-range-wrapper > input {

--- a/react/package.json
+++ b/react/package.json
@@ -9,7 +9,7 @@
     "exenv": "^1.2.2",
     "ramda": "^0.25.0",
     "react-draggable": "^3.0.5",
-    "react-jsonschema-form": "^1.0.0"
+    "react-jsonschema-form": "^1.0.1"
   },
   "devDependencies": {
     "apollo-client-preset": "^1.0.8",

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vtex/styleguide": "2.0.0-rc.39",
+    "@vtex/styleguide": "4.0.0",
     "exenv": "^1.2.2",
     "ramda": "^0.25.0",
     "react-draggable": "^3.0.5",

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "@vtex/styleguide": "4.0.0",
     "exenv": "^1.2.2",
     "ramda": "^0.25.0",
     "react-draggable": "^3.0.5",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1605,8 +1605,8 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
 fast-deep-equal@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -1950,7 +1950,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.19, iconv-lite@~0.4.13:
+iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
@@ -1959,6 +1959,12 @@ iconv-lite@^0.4.4:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
     safer-buffer "^2.1.0"
+
+iconv-lite@~0.4.13:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore-walk@^3.0.1:
   version "3.0.1"
@@ -3383,15 +3389,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
-prop-types@^15.6.0:
+prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -3491,9 +3489,9 @@ react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
-react-jsonschema-form@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.0.tgz#53ce38384a5df08e9ddc0d83b435af255c063078"
+react-jsonschema-form@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.3.tgz#83bf8c5330651a949d8b0ac644fb92c6665348b5"
   dependencies:
     ajv "^5.2.3"
     lodash.topath "^4.5.2"
@@ -3725,7 +3723,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
@@ -4108,8 +4106,8 @@ type-check@~0.3.2:
     prelude-ls "~1.1.2"
 
 ua-parser-js@^0.7.9:
-  version "0.7.17"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
+  version "0.7.18"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -4214,8 +4212,8 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
     iconv-lite "0.4.19"
 
 whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
 whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -32,12 +32,12 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
 
-"@vtex/styleguide@2.0.0-rc.39":
-  version "2.0.0-rc.39"
-  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-2.0.0-rc.39.tgz#24b9a19b89094ccc23ad93ea545c454704ee943c"
+"@vtex/styleguide@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-4.0.0.tgz#7f184fce82564a3cec46c4281d0d85ba4f6145ca"
   dependencies:
     react-responsive-modal "^2.0.1"
-    vtex-tachyons "^2.3.0"
+    vtex-tachyons "^2.5.1"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -4340,9 +4340,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vtex-tachyons@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-2.4.0.tgz#c95ba2303bef179826058997d1bc578468669ff2"
+vtex-tachyons@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-2.5.1.tgz#a56ec6d33417886c0e8755da383088b88bf437fe"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -32,13 +32,6 @@
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.5.3.tgz#91b728599544efbb7386d8b6633693a3c2e7ade5"
 
-"@vtex/styleguide@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-4.0.0.tgz#7f184fce82564a3cec46c4281d0d85ba4f6145ca"
-  dependencies:
-    react-responsive-modal "^2.0.1"
-    vtex-tachyons "^2.5.1"
-
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -974,10 +967,6 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-brcast@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/brcast/-/brcast-3.0.1.tgz#6256a8349b20de9eed44257a9b24d71493cd48dd"
-
 browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
@@ -1210,12 +1199,6 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-vendor@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
-  dependencies:
-    is-in-browser "^1.0.2"
-
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
@@ -1339,10 +1322,6 @@ diff@^3.2.0:
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
-
-dom-helpers@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -1931,7 +1910,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
@@ -1970,10 +1949,6 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
-
-hyphenate-style-name@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
 iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
@@ -2163,10 +2138,6 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-function@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
-
 is-generator-fn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-1.0.0.tgz#969d49e1bb3329f6bb7f09089be26578b2ddd46a"
@@ -2176,10 +2147,6 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
-
-is-in-browser@^1.0.2, is-in-browser@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-number-object@^1.0.3:
   version "1.0.3"
@@ -2734,81 +2701,6 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jss-camel-case@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jss-camel-case/-/jss-camel-case-6.1.0.tgz#ccb1ff8d6c701c02a1fed6fb6fb6b7896e11ce44"
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-
-jss-compose@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/jss-compose/-/jss-compose-5.0.0.tgz#ce01b2e4521d65c37ea42cf49116e5f7ab596484"
-  dependencies:
-    warning "^3.0.0"
-
-jss-default-unit@^8.0.2:
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
-
-jss-expand@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.1.0.tgz#b1ad74ec18631f34f65a2124fcfceb6400610e3d"
-
-jss-extend@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.2.0.tgz#4af09d0b72fb98ee229970f8ca852fec1ca2a8dc"
-  dependencies:
-    warning "^3.0.0"
-
-jss-global@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jss-global/-/jss-global-3.0.0.tgz#e19e5c91ab2b96353c227e30aa2cbd938cdaafa2"
-
-jss-nested@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
-  dependencies:
-    warning "^3.0.0"
-
-jss-preset-default@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.3.0.tgz#7bc91b0b282492557d36ed4e5c6d7c8cb3154bb8"
-  dependencies:
-    jss-camel-case "^6.1.0"
-    jss-compose "^5.0.0"
-    jss-default-unit "^8.0.2"
-    jss-expand "^5.1.0"
-    jss-extend "^6.2.0"
-    jss-global "^3.0.0"
-    jss-nested "^6.0.1"
-    jss-props-sort "^6.0.0"
-    jss-template "^1.0.1"
-    jss-vendor-prefixer "^7.0.0"
-
-jss-props-sort@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
-
-jss-template@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.1.tgz#09aed9d86cc547b07f53ef355d7e1777f7da430a"
-  dependencies:
-    warning "^3.0.0"
-
-jss-vendor-prefixer@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
-  dependencies:
-    css-vendor "^0.3.8"
-
-jss@^9.7.0:
-  version "9.8.1"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.1.tgz#e2ff250777ad657430e6edc47a63516541b888fa"
-  dependencies:
-    is-in-browser "^1.1.3"
-    symbol-observable "^1.1.0"
-    warning "^3.0.0"
-
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -3118,10 +3010,6 @@ needle@^2.2.0:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
-
-no-scroll@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.0.tgz#f8643b3ddb6a3bf94430e5ff31d26f21d082a695"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -3503,7 +3391,7 @@ prop-types@^15.5.8:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.6.0:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -3612,22 +3500,6 @@ react-jsonschema-form@^1.0.0:
     prop-types "^15.5.8"
     setimmediate "^1.0.5"
 
-react-jss@^8.1.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/react-jss/-/react-jss-8.4.0.tgz#7cb43d85dea56afafc8f0fd072ae27fcc0518950"
-  dependencies:
-    hoist-non-react-statics "^2.3.1"
-    jss "^9.7.0"
-    jss-preset-default "^4.3.0"
-    prop-types "^15.6.0"
-    theming "^1.3.0"
-
-react-minimalist-portal@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/react-minimalist-portal/-/react-minimalist-portal-2.1.1.tgz#d32c403f446c5cb91060e3a3c70beba8c3d08c8f"
-  dependencies:
-    prop-types "^15.6.0"
-
 react-reconciler@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
@@ -3637,17 +3509,6 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-responsive-modal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/react-responsive-modal/-/react-responsive-modal-2.0.1.tgz#4943446d861a417c172981c47bd512be97de17c8"
-  dependencies:
-    classnames "^2.2.5"
-    no-scroll "^2.1.0"
-    prop-types "^15.6.0"
-    react-jss "^8.1.0"
-    react-minimalist-portal "^2.1.1"
-    react-transition-group "^2.2.1"
-
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
@@ -3656,14 +3517,6 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
     react-is "^16.3.2"
-
-react-transition-group@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.1.tgz#31d611b33e143a5e0f2d94c348e026a0f3b474b6"
-  dependencies:
-    dom-helpers "^3.3.1"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.1"
 
 react@^16.3.1:
   version "16.3.2"
@@ -4158,7 +4011,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@^1.0.2, symbol-observable@^1.1.0:
+symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
@@ -4187,15 +4040,6 @@ test-exclude@^4.2.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
-
-theming@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/theming/-/theming-1.3.0.tgz#286d5bae80be890d0adc645e5ca0498723725bdc"
-  dependencies:
-    brcast "^3.0.1"
-    is-function "^1.0.1"
-    is-plain-object "^2.0.1"
-    prop-types "^15.5.8"
 
 throat@^4.0.0:
   version "4.1.0"
@@ -4340,10 +4184,6 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vtex-tachyons@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/vtex-tachyons/-/vtex-tachyons-2.5.1.tgz#a56ec6d33417886c0e8755da383088b88bf437fe"
-
 w3c-hr-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
@@ -4355,12 +4195,6 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
-
-warning@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
-  dependencies:
-    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Replace some of RJSF's default widgets with Styleguide components;
- Fix `ComponentEditor`'s internal z-index ;
- Restructure label logic;
- Fix `FieldTemplate`'s description logic;
- Move `ComponentEditor`'s top bar and buttons out of form;
- Make `ComponentEditor`'s close icon a button;
- Fix `BaseInput`'s `onChange` edge case bug and refactor;
- Bump RJSF;
- Create custom `ErrorListTemplate`, and move error messages and handling to widgets.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Addresses #19.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8486092/41248151-8135e1e8-6d86-11e8-9e35-83117509deff.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)
- New feature (a non-breaking change which adds functionality)