### PR TITLE
Fix - General fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.1] - 2018-6-13
 ### Changed
 - Move remaining `object` field logic from `FieldTemplate` to `ObjectFieldTemplate`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Move remaining `object` field logic from `FieldTemplate` to `ObjectFieldTemplate`.
+
+### Fixed
+- `ComponentEditor`'s top bar height @ mobile.
+- `ComponentEditor`'s Save & Cancel buttons height @ mobile.
+
+### Removed
+- Description from `object` fields.
 
 ## [1.8.0] - 2018-6-12
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pages-editor",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "title": "VTEX Pages Editor",
   "description": "The VTEX Pages framework editor components",
   "builders": {

--- a/react/components/ComponentEditor.js
+++ b/react/components/ComponentEditor.js
@@ -319,7 +319,7 @@ class ComponentEditor extends Component {
       <div className="w-100 near-black">
         <Draggable handle=".draggable">
           <div className={`br2-ns fixed z-max bg-white flex flex-column shadow-editor-desktop size-editor w-100 top-2-ns right-2-ns mt9-ns mh5-ns move animated ${animation} ${this._isMounted ? '' : 'fadeIn'}`} style={{ animationDuration: '0.2s' }} >
-            <div className="bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 flex justify-between br2-ns br--top-ns draggable z-max">
+            <div className="flex flex-none justify-between bg-serious-black white fw7 f4 ph6 pv5 lh-copy w-100 br2-ns br--top-ns draggable z-max">
               <div>
                 {displayName}
               </div>
@@ -344,7 +344,7 @@ class ComponentEditor extends Component {
                 <button className="dn" type="submit" />
               </Form>
             </div>
-            <div className="flex w-100 bt bw2 b--light-silver">
+            <div className="w-100 flex flex-none bt bw2 b--light-silver">
               <div className="w-50 flex items-center justify-center bg-near-white hover-bg-light-silver hover-heavy-blue br bw2 b--light-silver">
                 <Button
                   block

--- a/react/components/form/FieldTemplate.js
+++ b/react/components/form/FieldTemplate.js
@@ -1,64 +1,31 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React from 'react'
 
-function Label(props) {
-  const { label, required, id, type } = props
-  if (!label) {
-    return <div />
-  }
-  return (
-    <label className="control-label f6 db gray" htmlFor={id}>
-      {label}
-      {required && <span className="required">*</span>}
-    </label>
-  )
-}
-
-Label.propTypes = {
-  id: PropTypes.string,
-  label: PropTypes.string,
-  required: PropTypes.bool,
-}
-
-export default function FieldTemplate(props) {
-  const {
-    id,
-    classNames,
-    label,
-    children,
-    errors,
-    help,
-    description,
-    hidden,
-    required,
-    schema,
-    rawErrors,
-  } = props
-
+const FieldTemplate = ({
+  children,
+  classNames,
+  hidden,
+}) => {
   if (hidden) {
     return children
   }
 
   return (
     <div className={`${classNames} w-100`}>
-      {schema.type === 'object' && <Label label={label} required={required} id={id} />}
-      {schema.type === 'object' && description}
       {children}
-      {help}
     </div>
   )
 }
 
-FieldTemplate.propTypes = {
-  id: PropTypes.string,
-  classNames: PropTypes.string,
-  label: PropTypes.string,
-  help: PropTypes.element,
-  required: PropTypes.bool,
-  description: PropTypes.element,
-  errors: PropTypes.object,
-  children: PropTypes.element,
-  displayLabel: PropTypes.bool,
-  hidden: PropTypes.bool,
-  rawErrors: PropTypes.arrayOf(PropTypes.string),
+FieldTemplate.defaultProps = {
+  classNames: '',
+  hidden: false,
 }
+
+FieldTemplate.propTypes = {
+  children: PropTypes.element,
+  classNames: PropTypes.string,
+  hidden: PropTypes.bool,
+}
+
+export default FieldTemplate

--- a/react/components/form/ObjectFieldTemplate.js
+++ b/react/components/form/ObjectFieldTemplate.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import React, { Fragment } from 'react'
 
 const ObjectFieldTemplate = ({
-  description,
   idSchema: { $id: id },
   properties,
   required,
@@ -15,20 +14,17 @@ const ObjectFieldTemplate = ({
         {required && '*'}
       </label>
     )}
-    {description && <div className="f6 gray">{description}</div>}
     {properties.map(property => property.content)}
   </Fragment>
 )
 
 ObjectFieldTemplate.defaultProps = {
-  description: '',
   properties: [],
   required: false,
   title: '',
 }
 
 ObjectFieldTemplate.propTypes = {
-  description: PropTypes.string,
   idSchema: PropTypes.object.isRequired,
   properties: PropTypes.array,
   required: PropTypes.bool,

--- a/react/components/form/ObjectFieldTemplate.js
+++ b/react/components/form/ObjectFieldTemplate.js
@@ -1,14 +1,38 @@
-import React from 'react'
 import PropTypes from 'prop-types'
+import React, { Fragment } from 'react'
 
-export default function ObjectFieldTemplate(props) {
-  return (
-    <div>
-      {props.properties.map(prop => prop.content)}
-    </div>
-  )
+const ObjectFieldTemplate = ({
+  description,
+  idSchema: { $id: id },
+  properties,
+  required,
+  title,
+}) => (
+  <Fragment>
+    {title && (
+      <label className="db f6 gray" htmlFor={id}>
+        {title}
+        {required && '*'}
+      </label>
+    )}
+    {description && <div className="f6 gray">{description}</div>}
+    {properties.map(property => property.content)}
+  </Fragment>
+)
+
+ObjectFieldTemplate.defaultProps = {
+  description: '',
+  properties: [],
+  required: false,
+  title: '',
 }
 
 ObjectFieldTemplate.propTypes = {
+  description: PropTypes.string,
+  idSchema: PropTypes.object.isRequired,
   properties: PropTypes.array,
+  required: PropTypes.bool,
+  title: PropTypes.string,
 }
+
+export default ObjectFieldTemplate

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -25,17 +25,6 @@ html, body {
   box-shadow: 0px -2px 1px 0px rgba(0,0,0,0.25);
 }
 
-.editor-form > .field-description {
-  background-color: #F7F9FA;
-  margin: 0;
-  padding: 20px 24px;
-  margin: -14px -24px 14px;
-  font-size: 14px;
-  color: #142032;
-  line-height: 1.5rem;
-  font-style: normal;
-}
-
 .form-group {
   padding-top: 10px;
   padding-bottom: 10px;


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Move remaining `object` field logic from `FieldTemplate` to `ObjectFieldTemplate`;
- Fix `ComponentEditor`'s top bar height @ mobile;
- Fix `ComponentEditor`'s Save & Cancel buttons height @ mobile;
- Remove description from `object` fields.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Mobile bugs.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/.

#### Screenshots or example usage
Before:

![image](https://user-images.githubusercontent.com/8486092/41372774-a7828ed8-6f24-11e8-924e-24e0b06967ed.png)

<hr />

After:

![image](https://user-images.githubusercontent.com/8486092/41372656-4e6250ea-6f24-11e8-831d-02277642cf48.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)