### PR TITLE
Fix maximum and minimum attributes of the range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `BaseInput` not passing min and max props to `Input` component
 
 ## [1.9.0] - 2018-6-18
 ### Added

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -8,6 +8,8 @@ const BaseInput = props => {
     disabled,
     id,
     label,
+    max,
+    min,
     onBlur,
     onFocus,
     options,
@@ -36,6 +38,8 @@ const BaseInput = props => {
       errorMessage={currentError}
       helpText={schema.description}
       label={label}
+      max={max}
+      min={min}
       onBlur={onBlur && (event => onBlur(id, event.target.value))}
       onChange={_onChange}
       onFocus={onFocus && (event => onFocus(id, event.target.value))}
@@ -62,6 +66,8 @@ BaseInput.propTypes = {
   disabled: PropTypes.bool,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
+  max: PropTypes.number,
+  min: PropTypes.number,
   onBlur: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Pass over the `min` and `max` props from the `BaseInput` to the `Input` component.

#### What problem is this solving?
Fixes #32 

#### How should this be manually tested?
[Access this workspace](https://waza--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
