### PR TITLE
Fix - First object field style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `border-top`, `margin-top` and `padding-top` from `ComponentEditor`'s first object field.
 
 ## [1.9.1] - 2018-6-20
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.2] - 2018-6-25
 ### Removed
 - `border-top`, `margin-top` and `padding-top` from `ComponentEditor`'s first object field.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pages-editor",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "title": "VTEX Pages Editor",
   "description": "The VTEX Pages framework editor components",
   "builders": {

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -31,12 +31,18 @@ html, body {
 }
 
 .form-group.field.field-object > label {
-  color: #C3C4C5;
-  text-transform: uppercase;
-  font-weight: 700;
-  padding: 20px 0px 5px;
-  margin-top: 10px;
   border-top: 2px solid #F0F2F4;
+  color: #C3C4C5;
+  font-weight: 700;
+  margin-top: 10px;
+  padding: 20px 0px 5px;
+  text-transform: uppercase;
+}
+
+.form-group.field.field-object:first-child > label {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .checkbox span {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Remove top border and spacing from `ComponentEditor`'s first object field.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Unnecessary top border and spacing in the first object field, which makes it look like there should be a field above it.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/.

#### Screenshots or example usage
Before:

![image](https://user-images.githubusercontent.com/8486092/41872433-3e0296c4-7898-11e8-9314-a67348b13acc.png)

<hr />

After:

![image](https://user-images.githubusercontent.com/8486092/41872368-04616af8-7898-11e8-9542-4412e8c1dff1.png)

#### Types of changes
- Bug fix (a non-breaking change which fixes an issue)