### PR TITLE
Feature - Styleguide Tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump Styleguide's version to major 5.
+- Replace custom `ModeSwitcher`'s tabs with Styleguide's `Tabs`.
 
 ## [1.9.2] - 2018-6-25
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "vtex.pages-graphql": "1.x",
-    "vtex.styleguide": "4.x"
+    "vtex.styleguide": "5.x"
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],

--- a/react/components/ComponentEditor/ModeSwitcher.js
+++ b/react/components/ComponentEditor/ModeSwitcher.js
@@ -1,22 +1,18 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Tabs, Tab } from 'vtex.styleguide'
 
 const ModeSwitcher = ({ activeMode, modes, onSwitch }) => (
-  <div className="h3 flex justify-center bt bb bw1 b--light-gray">
+  <Tabs>
     {modes.map(mode => (
-      <div
-        className={`w-50 flex items-center justify-center bg-near-white hover-bg-light-silver pointer bb bw2 ${
-          activeMode === mode
-            ? 'b--blue'
-            : 'b--near-white hover-b--light-silver'
-          }`}
+      <Tab
+        active={mode === activeMode}
         key={mode}
+        label={mode.toUpperCase()}
         onClick={() => onSwitch(mode)}
-      >
-        {mode.charAt(0).toUpperCase() + mode.slice(1)}
-      </div>
+      />
     ))}
-  </div>
+  </Tabs>
 )
 
 ModeSwitcher.defaultProps = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Bump `vtex.styleguide`'s version to major 5;
- Replace custom `ModeSwitcher`'s tabs with Styleguide's `Tabs`.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The purpose of this PR is to replace custom tabs with the ones from Styleguide.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8486092/41999322-999217d4-7a33-11e8-9288-08dd79628992.png)

#### Types of changes
- New feature (a non-breaking change which adds functionality)