### PR TITLE
Feature - Full width ModeSwitcher tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make `ModeSwitcher`'s tabs use container's full width.
 
 ## [1.10.0] - 2018-6-28
 ### Changed

--- a/react/components/ComponentEditor/ModeSwitcher.js
+++ b/react/components/ComponentEditor/ModeSwitcher.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Tabs, Tab } from 'vtex.styleguide'
 
 const ModeSwitcher = ({ activeMode, modes, onSwitch }) => (
-  <Tabs>
+  <Tabs fullWidth>
     {modes.map(mode => (
       <Tab
         active={mode === activeMode}


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Make `ModeSwitcher`'s tabs use container's full width.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Unnecessary spare space.

#### How should this be manually tested?
Workspace: https://alan--lojadaju.myvtex.com/.

#### Screenshots or example usage
Before:
![image](https://user-images.githubusercontent.com/8486092/42384425-52a24234-8110-11e8-9f8c-59f4d881e4e5.png)

<hr />

After:
![image](https://user-images.githubusercontent.com/8486092/42384345-198977ba-8110-11e8-9633-df789298c087.png)

#### Types of changes
- New feature (a non-breaking change which adds functionality)