### PR TITLE
Fix drag handle display condition and add more click behavior

### DIFF
--- a/react/components/form/ArrayFieldTemplate.js
+++ b/react/components/form/ArrayFieldTemplate.js
@@ -24,6 +24,7 @@ const ArrayList = SortableContainer(({ items, schema, openedItem, onOpen, onClos
         onOpen={onOpen(element.index)}
         onClose={onClose}
         formIndex={element.index}
+        showDragHandle={items.length > 1}
         {...element}
       />
     ))}
@@ -74,8 +75,17 @@ class ArrayFieldTemplate extends Component {
     })
   }
 
+  handleAddItem = e => {
+    const { onAddClick, items } = this.props
+
+    onAddClick(e)
+    this.setState({
+      openedItem: items.length,
+    })
+  }
+
   render() {
-    const { items, onAddClick, canAdd, schema } = this.props
+    const { items, canAdd, schema } = this.props
     const { openedItem, sorting } = this.state
 
     return (
@@ -101,7 +111,7 @@ class ArrayFieldTemplate extends Component {
             <Button
               variation="secondary"
               size="small"
-              onClick={onAddClick}
+              onClick={this.handleAddItem}
             >
               + Add More
             </Button>

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -24,6 +24,7 @@ class ArrayFieldTemplateItem extends Component {
     isOpen: PropTypes.bool,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
+    showDragHandle: PropTypes.bool,
   }
 
   handleLabelClick = e => {
@@ -44,15 +45,16 @@ class ArrayFieldTemplateItem extends Component {
       hasRemove,
       onDropIndexClick,
       isOpen,
+      showDragHandle,
     } = this.props
 
     const title = children.props.formData.__editorItemTitle || schema.items.properties.__editorItemTitle.default
 
     return (
-      <div className="accordion-item bb b--light-silver">
+      <div className={`accordion-item bb b--light-silver ${showDragHandle ? '' : 'accordion-item--handle-hidden'}`}>
         <div className="accordion-label" onClick={this.handleLabelClick}>
           <div className="flex items-center">
-            <Handle />
+            {showDragHandle && <Handle />}
             <label className="f6 accordion-label-title">
               {title}
             </label>

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -257,6 +257,10 @@ html, body {
   padding-left: 26px;
 }
 
+.accordion-item--handle-hidden .accordion-label {
+  padding-left: 16px;
+}
+
 .accordion-item--dragged .accordion-label {
   box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2);
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Drag handle should only be displayed when there are more than 1 item in the list, and when you click the "Add More" button the newly added item should be opened.

#### How should this be manually tested?
[Workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
