### PR TITLE
Accordion items animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Accordion behavior on the array fields.
+- Animation on accordion items.
 
 ## [1.10.0] - 2018-6-28
 ### Changed

--- a/react/components/ComponentEditor.tsx
+++ b/react/components/ComponentEditor.tsx
@@ -265,10 +265,13 @@ class ComponentEditor extends Component<ComponentEditorProps & RenderContextProp
           translatedSchema.minItems = 1
         }
 
-        translatedSchema.items.properties.__editorItemTitle = {
-          default: translatedSchema.items.title,
-          title: 'Item title',
-          type: 'string',
+        translatedSchema.items.properties = {
+          __editorItemTitle: {
+            default: translatedSchema.items.title,
+            title: 'Item title',
+            type: 'string',
+          },
+          ...translatedSchema.items.properties,
         }
       }
 

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -84,14 +84,14 @@ class ArrayFieldTemplateItem extends Component {
         <div
           className={`accordion-content ${isOpen ? 'accordion-content--open' : ''}`}
         >
-          {isOpen && (
-            <Transition
-              from={{ opacity: 0, height: 0 }}
-              enter={{ opacity: 1, height: 'auto' }}
-              leave={{ opacity: 0, height: 0 }}
-              render={this.renderChildren}
-            />
-          )}
+          <Transition
+            keys={isOpen ? ['children'] : []}
+            from={{ opacity: 0, height: 0 }}
+            enter={{ opacity: 1, height: 'auto' }}
+            leave={{ opacity: 0, height: 0 }}
+          >
+            {isOpen ? [this.renderChildren] : []}
+          </Transition>
         </div>
       </div>
     )

--- a/react/components/form/ArrayFieldTemplateItem.js
+++ b/react/components/form/ArrayFieldTemplateItem.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { SortableElement, SortableHandle } from 'react-sortable-hoc'
+import { Transition } from 'react-spring'
 
 import TrashSimple from '../icons/TrashSimple'
 import DragHandle from '../icons/DragHandle'
@@ -37,6 +38,16 @@ class ArrayFieldTemplateItem extends Component {
     }
   }
 
+  renderChildren = styles => {
+    const { children } = this.props
+
+    return (
+      <div style={styles}>
+        {children}
+      </div>
+    )
+  }
+
   render() {
     const {
       children,
@@ -65,13 +76,22 @@ class ArrayFieldTemplateItem extends Component {
                 className="accordion-icon-button accordion-icon-button--remove"
                 onClick={stopPropagation(onDropIndexClick(formIndex))}
               >
-                <TrashSimple size="15" />
+                <TrashSimple size={15} />
               </button>
             )}
           </div>
         </div>
-        <div className="accordion-content">
-          {isOpen && children}
+        <div
+          className={`accordion-content ${isOpen ? 'accordion-content--open' : ''}`}
+        >
+          {isOpen && (
+            <Transition
+              from={{ opacity: 0, height: 0 }}
+              enter={{ opacity: 1, height: 'auto' }}
+              leave={{ opacity: 0, height: 0 }}
+              render={this.renderChildren}
+            />
+          )}
         </div>
       </div>
     )

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -323,7 +323,8 @@ html, body {
 .accordion-handle {
   display: none;
   position: absolute;
-  left: 8px;
+  left: 5px;
+  padding: 3px;
 }
 
 .accordion-item--dragged .accordion-handle,

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -271,10 +271,6 @@ html, body {
   box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2);
 }
 
-.accordion-item--dragged .accordion-content {
-  display: none;
-}
-
 .accordion-label-buttons {
   display: none;
 }
@@ -333,4 +329,8 @@ html, body {
 .accordion-item--dragged .accordion-handle,
 .accordion-label:hover .accordion-handle {
   display: block;
+}
+
+.accordion-item--dragged .accordion-content {
+  display: none;
 }

--- a/react/editbar.global.css
+++ b/react/editbar.global.css
@@ -331,6 +331,10 @@ html, body {
   display: block;
 }
 
+.accordion-content {
+  overflow: hidden;
+}
+
 .accordion-item--dragged .accordion-content {
   display: none;
 }

--- a/react/package.json
+++ b/react/package.json
@@ -8,10 +8,12 @@
   "dependencies": {
     "exenv": "^1.2.2",
     "ramda": "^0.25.0",
+    "react-animate-height": "^2.0.3",
     "react-draggable": "^3.0.5",
     "react-dropzone": "^4.2.13",
     "react-jsonschema-form": "^1.0.1",
-    "react-sortable-hoc": "^0.8.3"
+    "react-sortable-hoc": "^0.8.3",
+    "react-spring": "^5.4.0"
   },
   "devDependencies": {
     "@types/graphql": "^0.12.5",

--- a/react/package.json
+++ b/react/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^16.0.5",
     "@types/react-helmet": "^5.0.5",
     "@types/react-intl": "^2.3.5",
+    "@types/react-jsonschema-form": "^1.0.7",
     "apollo-client-preset": "^1.0.8",
     "babel": "^6.23.0",
     "babel-jest": "^22.4.3",

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "exenv": "^1.2.2",
     "ramda": "^0.25.0",
-    "react-animate-height": "^2.0.3",
     "react-draggable": "^3.0.5",
     "react-dropzone": "^4.2.13",
     "react-jsonschema-form": "^1.0.1",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -68,7 +68,7 @@
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.8.tgz#de56b21b67e39df24bc0fc7e67b437976b666919"
 
-"@types/react@*", "@types/react@>=16", "@types/react@^16.3.16":
+"@types/react@*", "@types/react@^16.3.16":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
   dependencies:
@@ -3476,7 +3476,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7, prop-types@^15.6.1:
+prop-types@^15.5.7:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -3543,15 +3543,6 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
-
-react-animate-height@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-2.0.3.tgz#7ee31ab2b357e25d68f9c6f53fcba8834abc17a1"
-  dependencies:
-    classnames "^2.2.5"
-    prop-types "^15.6.1"
-  optionalDependencies:
-    "@types/react" ">=16"
 
 react-apollo@^2.1.3:
   version "2.1.3"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -16,6 +16,13 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/runtime@7.0.0-beta.51":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@types/async@2.0.47":
   version "2.0.47"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.0.47.tgz#f49ba1dd1f189486beb6e1d070a850f6ab4bd521"
@@ -61,7 +68,7 @@
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.8.tgz#de56b21b67e39df24bc0fc7e67b437976b666919"
 
-"@types/react@*", "@types/react@^16.3.16":
+"@types/react@*", "@types/react@>=16", "@types/react@^16.3.16":
   version "16.4.6"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.6.tgz#5024957c6bcef4f02823accf5974faba2e54fada"
   dependencies:
@@ -1228,6 +1235,10 @@ core-js@^1.0.0:
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3465,7 +3476,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.7:
+prop-types@^15.5.7, prop-types@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -3532,6 +3543,15 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-animate-height@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-animate-height/-/react-animate-height-2.0.3.tgz#7ee31ab2b357e25d68f9c6f53fcba8834abc17a1"
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.1"
+  optionalDependencies:
+    "@types/react" ">=16"
 
 react-apollo@^2.1.3:
   version "2.1.3"
@@ -3605,6 +3625,12 @@ react-sortable-hoc@^0.8.3:
     invariant "^2.2.1"
     prop-types "^15.5.7"
 
+react-spring@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-5.4.0.tgz#4989b10dd0fac20a14f43ef3de78fabec705f832"
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.51"
+
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
@@ -3660,7 +3686,7 @@ regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -39,6 +39,10 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/intl/-/intl-1.2.0.tgz#1245511f13064402087979f498764611a3c758fc"
 
+"@types/json-schema@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-6.0.1.tgz#a761975746f1c1b2579c62e3a4b5e88f986f7e2e"
+
 "@types/node@*":
   version "9.6.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.6.tgz#439b91f9caf3983cad2eef1e11f6bedcbf9431d2"
@@ -67,6 +71,13 @@
 "@types/react-intl@^2.3.5":
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/@types/react-intl/-/react-intl-2.3.8.tgz#de56b21b67e39df24bc0fc7e67b437976b666919"
+
+"@types/react-jsonschema-form@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-jsonschema-form/-/react-jsonschema-form-1.0.7.tgz#009334a4e21d988b38b095b2cef23e5819fbc2d4"
+  dependencies:
+    "@types/json-schema" "*"
+    "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.3.16":
   version "16.4.6"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add animation on the open and close of the accordion items.

#### What problem is this solving?
The ui was a bit confusing without the animations, and made the user confused about what was going on when they add a new item, or move items.

##### Known bugs
There are a few bugs remaining, that exists on the actual library used to do the drag and drop, because it doesn't have a really good support for the children being animated.

- When a item is open, and you drag a _different_ item above the one that was open, you can't drag it past the previously opened item.
 - Similarly, when you start dragging an item that was open, you can't drag past the position it was.

#### How should this be manually tested?
[Access my workspace](https://lucas--storecomponents.myvtex.com/).

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
