### PR TITLE
Remove console errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.3] - 2018-07-18
 ### Fixed
 - Attributes name in the svg icon.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Attributes name in the svg icon.
+
 ### Changed
 - Accordion behavior on the array fields.
 - Animation on accordion items.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pages-editor",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "title": "VTEX Pages Editor",
   "description": "The VTEX Pages framework editor components",
   "builders": {

--- a/react/components/ComponentList.tsx
+++ b/react/components/ComponentList.tsx
@@ -8,23 +8,23 @@ const getComponentSchema = (component: string, props: any) => {
   const ComponentImpl = component && getImplementation(component)
   return ComponentImpl
     && ((ComponentImpl.hasOwnProperty('schema') && ComponentImpl.schema)
-    || (ComponentImpl.hasOwnProperty('getSchema') && ComponentImpl.getSchema(props)))
+      || (ComponentImpl.hasOwnProperty('getSchema') && ComponentImpl.getSchema(props)))
 }
 
 const ComponentIcon = () => (<svg width="16px" height="16px" viewBox="0 0 16 16">
-   <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-       <g id="path-minus" stroke="#727273" stroke-width="1.4">
-           <polyline id="Shape" points="0.5 7.5 0.5 5.5 2.5 5.5"></polyline>
-           <path d="M0.5,11.531 L0.5,9.5" id="Shape"></path>
-           <polyline id="Shape" points="2.5 15.5 0.5 15.5 0.5 13.5"></polyline>
-           <path d="M6.5,15.5 L4.5,15.5" id="Shape"></path>
-           <polyline id="Shape" points="10.5 13.5 10.5 15.5 8.5 15.5"></polyline>
-           <path d="M10.5,9.5 L10.5,11.5" id="Shape"></path>
-           <polyline id="Shape" points="8.5 5.5 10.5 5.5 10.5 7.5"></polyline>
-           <path d="M4.5,5.5 L6.5,5.5" id="Shape"></path>
-           <polyline id="Shape" points="5.5 3.5 5.5 0.5 15.5 0.5 15.5 10.5 12.5 10.5"></polyline>
-       </g>
-   </g>
+  <g id="Artboard" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round">
+    <g id="path-minus" stroke="#727273" strokeWidth="1.4">
+      <polyline id="Shape" points="0.5 7.5 0.5 5.5 2.5 5.5"></polyline>
+      <path d="M0.5,11.531 L0.5,9.5" id="Shape"></path>
+      <polyline id="Shape" points="2.5 15.5 0.5 15.5 0.5 13.5"></polyline>
+      <path d="M6.5,15.5 L4.5,15.5" id="Shape"></path>
+      <polyline id="Shape" points="10.5 13.5 10.5 15.5 8.5 15.5"></polyline>
+      <path d="M10.5,9.5 L10.5,11.5" id="Shape"></path>
+      <polyline id="Shape" points="8.5 5.5 10.5 5.5 10.5 7.5"></polyline>
+      <path d="M4.5,5.5 L6.5,5.5" id="Shape"></path>
+      <polyline id="Shape" points="5.5 3.5 5.5 0.5 15.5 0.5 15.5 10.5 12.5 10.5"></polyline>
+    </g>
+  </g>
 </svg>)
 
 const isDifferentPage = (treePath: string, page: string, pages: string[]) => {
@@ -59,7 +59,7 @@ class ComponentList extends Component<{} & RenderContextProps & EditorContextPro
 
   public renderComponentButton = (treePath: string) => {
     const { runtime: { extensions, page, pages } } = this.props
-    const { component, props = {} } =  extensions[treePath]
+    const { component, props = {} } = extensions[treePath]
     const schema = getComponentSchema(component, props)
 
     if (!schema || !schema.title || isDifferentPage(treePath, page, Object.keys(pages))) {
@@ -67,22 +67,22 @@ class ComponentList extends Component<{} & RenderContextProps & EditorContextPro
     }
 
     return (
-        <button
-          key={treePath}
-          type="button"
-          data-tree-path={treePath}
-          onClick={this.onEdit}
-          onMouseOver={this.handleMouseOver}
-          onMouseOut={this.handleMouseOut}
-          className={
-            'dark-gray bg-white pt5 pointer hover-bg-light-silver w-100 tl bn ph0 pb0'
-          }
-          style={{ animationDuration: '0.2s' }}
-        >
-          <div className="bb b--light-silver w-100 pb5">
-            <span className="pl5"><ComponentIcon/></span><span className="f6 fw5 pl5 track-1 ttu"><FormattedMessage id={schema.title}/></span>
-          </div>
-        </button>
+      <button
+        key={treePath}
+        type="button"
+        data-tree-path={treePath}
+        onClick={this.onEdit}
+        onMouseOver={this.handleMouseOver}
+        onMouseOut={this.handleMouseOut}
+        className={
+          'dark-gray bg-white pt5 pointer hover-bg-light-silver w-100 tl bn ph0 pb0'
+        }
+        style={{ animationDuration: '0.2s' }}
+      >
+        <div className="bb b--light-silver w-100 pb5">
+          <span className="pl5"><ComponentIcon /></span><span className="f6 fw5 pl5 track-1 ttu"><FormattedMessage id={schema.title} /></span>
+        </div>
+      </button>
     )
   }
 

--- a/react/images/PathMinus.js
+++ b/react/images/PathMinus.js
@@ -5,15 +5,15 @@ class PathMinus extends Component {
   render() {
     return (
       <svg width="17" height="17" viewBox="0 0 17 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0 2V0H2" transform="translate(1 6)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M0 2.031V0" transform="translate(1 10)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M2 2H0V0" transform="translate(1 14)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M2 0H0" transform="translate(5 16)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M2 0V2H0" transform="translate(9 14)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M0 0V2" transform="translate(11 10)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M0 0H2V2" transform="translate(9 6)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M0 0H2" transform="translate(5 6)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-        <path d="M0 3V0H10V10H7" transform="translate(6 1)" stroke="#727273" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M0 2V0H2" transform="translate(1 6)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 2.031V0" transform="translate(1 10)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M2 2H0V0" transform="translate(1 14)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M2 0H0" transform="translate(5 16)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M2 0V2H0" transform="translate(9 14)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 0V2" transform="translate(11 10)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 0H2V2" transform="translate(9 6)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 0H2" transform="translate(5 6)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M0 3V0H10V10H7" transform="translate(6 1)" stroke="#727273" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
     )
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The name of the attributes of the SVG icon was incorrect, so there were lots of errors appearing in the console.
![captura de tela de 2018-07-17 14-05-46](https://user-images.githubusercontent.com/12852518/42833815-a159f048-89cb-11e8-923e-006c45823c24.png)


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
https://waza2--storecomponents.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
