### PR TITLE
Fix/pages editor form

### DIFF
--- a/react/components/PageEditor.tsx
+++ b/react/components/PageEditor.tsx
@@ -194,7 +194,6 @@ class PageEditor extends Component<any, any> {
       id: value,
       path: '/',
     }
-    console.log(route.context)
     this.setState({
       context: route.context,
       declarer: route.declarer,

--- a/react/components/PageEditor.tsx
+++ b/react/components/PageEditor.tsx
@@ -194,7 +194,7 @@ class PageEditor extends Component<any, any> {
       id: value,
       path: '/',
     }
-
+    console.log(route.context)
     this.setState({
       context: route.context,
       declarer: route.declarer,
@@ -238,9 +238,8 @@ class PageEditor extends Component<any, any> {
     partialSchema.properties.path.disabled = !isEditableRoute
     partialSchema.properties.context.disabled = !isEditableRoute
 
-    const schemaProperties = selectedRouteId
-      ? partialSchema.properties
-      : omit(['routeId', 'path', 'context'], partialSchema.properties)
+    const omittedProperties = selectedRouteId ? ['context'] : ['routeId', 'path', 'context']
+    const schemaProperties = omit(omittedProperties, partialSchema.properties)
 
     const schema = {
       ...partialSchema,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove context from PagesEditor form.

#### What problem is this solving?
The user will no longer need to select the context when creating a page.

#### How should this be manually tested?
* Access admin pages;
* Create a new page and check that there's no more context field in the form at any route type.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
