### PR TITLE
Add site scope to certain components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Site scope option when the component being edited is not defined only to the current page.
 
 ## [1.12.5] - 2018-07-19
 ### Fixed
-- Remove `template` and `site` scope conditions
+- Remove `template` and `site` scope conditions.
 
 ## [1.12.4] - 2018-07-18
 ### Fixed
@@ -39,7 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.9.1] - 2018-6-20
 ### Fixed
-- Fix `BaseInput` not passing min and max props to `Input` component
+- Fix `BaseInput` not passing min and max props to `Input` component.
 
 ## [1.9.0] - 2018-6-18
 ### Added

--- a/react/components/conditions/ConditionSection.tsx
+++ b/react/components/conditions/ConditionSection.tsx
@@ -36,7 +36,7 @@ export default class ConditionSection extends Component<ConditionSectionProps & 
   }
 
   public renderConditions () {
-    const { conditions, activeConditions, multiple, type} = this.props
+    const { conditions, activeConditions, multiple, type, shouldEnable } = this.props
 
     return map(c => {
       const message = c.message || c.conditionId
@@ -46,6 +46,7 @@ export default class ConditionSection extends Component<ConditionSectionProps & 
         <div className="dark-gray mb3" key={id}>
           <input className="mr3" type={multiple ? 'checkbox' : 'radio'}
             checked={contains(id, activeConditions)}
+            disabled={(!shouldEnable && id==='site')?true:false}
             id={`condition-${id}`}
             name={type}
             onChange={this.handleInputChange}

--- a/react/components/conditions/ConditionSection.tsx
+++ b/react/components/conditions/ConditionSection.tsx
@@ -1,14 +1,15 @@
 import PropTypes from 'prop-types'
 import { contains, map } from 'ramda'
 import React, { Component, Fragment } from 'react'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, injectIntl, intlShape  } from 'react-intl'
+import { Radio, Checkbox } from 'vtex.styleguide'
 
 interface ConditionSectionProps {
   multiple?: boolean
   type: string
 }
 
-export default class ConditionSection extends Component<ConditionSectionProps & EditorConditionSection> {
+class ConditionSection extends Component<ConditionSectionProps & EditorConditionSection> {
   public static propTypes = {
     activeConditions: PropTypes.arrayOf(PropTypes.string),
     addCondition: PropTypes.func,
@@ -16,6 +17,8 @@ export default class ConditionSection extends Component<ConditionSectionProps & 
     multiple: PropTypes.bool,
     removeCondition: PropTypes.func,
     type: PropTypes.string,
+    intl: intlShape.isRequired,
+    shouldEnable: PropTypes.bool
   }
 
   public static defaultProps = {
@@ -44,17 +47,26 @@ export default class ConditionSection extends Component<ConditionSectionProps & 
 
       return (
         <div className="dark-gray mb3" key={id}>
-          <input className="mr3" type={multiple ? 'checkbox' : 'radio'}
-            checked={contains(id, activeConditions)}
-            disabled={(!shouldEnable && id==='site')?true:false}
-            id={`condition-${id}`}
-            name={type}
-            onChange={this.handleInputChange}
-            value={id}
+          {
+            multiple
+            ? <Checkbox
+                checked={contains(id, activeConditions)}
+                id={`condition-${id}`}
+                name={type}
+                onChange={this.handleInputChange}
+                value={id}
+                label={this.props.intl.formatMessage({id: message})}
               />
-          <label htmlFor={`condition-${id}`}>
-            <FormattedMessage id={message} />
-          </label>
+            : <Radio
+                checked={contains(id, activeConditions)}
+                disabled={!shouldEnable && id === 'site'}
+                id={`condition-${id}`}
+                name={type}
+                onChange={this.handleInputChange}
+                value={id}
+                label={this.props.intl.formatMessage({id: message})}
+              />
+          }
         </div>
       )
     }, conditions)
@@ -71,3 +83,5 @@ export default class ConditionSection extends Component<ConditionSectionProps & 
     )
   }
 }
+
+export default injectIntl(ConditionSection)

--- a/react/components/conditions/ConditionSection.tsx
+++ b/react/components/conditions/ConditionSection.tsx
@@ -18,7 +18,7 @@ class ConditionSection extends Component<ConditionSectionProps & EditorCondition
     removeCondition: PropTypes.func,
     type: PropTypes.string,
     intl: intlShape.isRequired,
-    shouldEnable: PropTypes.bool
+    shouldEnableSite: PropTypes.bool
   }
 
   public static defaultProps = {
@@ -39,7 +39,7 @@ class ConditionSection extends Component<ConditionSectionProps & EditorCondition
   }
 
   public renderConditions () {
-    const { conditions, activeConditions, multiple, type, shouldEnable } = this.props
+    const { conditions, activeConditions, multiple, type, shouldEnableSite } = this.props
 
     return map(c => {
       const message = c.message || c.conditionId
@@ -59,7 +59,7 @@ class ConditionSection extends Component<ConditionSectionProps & EditorCondition
               />
             : <Radio
                 checked={contains(id, activeConditions)}
-                disabled={!shouldEnable && id === 'site'}
+                disabled={!shouldEnableSite && id === 'site'}
                 id={`condition-${id}`}
                 name={type}
                 onChange={this.handleInputChange}

--- a/react/components/conditions/ConditionSelector.tsx
+++ b/react/components/conditions/ConditionSelector.tsx
@@ -14,6 +14,10 @@ const scopeConditions = [
   {
     id: 'route',
     message: 'pages.conditions.scope.route',
+  },
+  {
+    id: 'site',
+    message: 'pages.conditions.scope.site',
   }
 ]
 
@@ -39,7 +43,7 @@ class ConditionSelector extends Component<{} & RenderContextProps & EditorContex
   }
 
   public render() {
-    const { editor: { conditions, activeConditions, addCondition, removeCondition, setScope, scope, setDevice}, runtime: { device } } = this.props
+    const { editor: { conditions, activeConditions, addCondition, removeCondition, setScope, scope, setDevice, editTreePath }, runtime: { device, page } } = this.props
 
     return (
       <div className="near-black">
@@ -48,6 +52,7 @@ class ConditionSelector extends Component<{} & RenderContextProps & EditorContex
         <div className="dark-gray">
           <div className="pl5 mb5">
             <ConditionSection type="scope"
+              shouldEnable={editTreePath && !editTreePath.startsWith(page)}
               conditions={scopeConditions as any}
               activeConditions={[scope]}
               addCondition={setScope as any}

--- a/react/components/conditions/ConditionSelector.tsx
+++ b/react/components/conditions/ConditionSelector.tsx
@@ -57,7 +57,7 @@ class ConditionSelector extends Component<{} & RenderContextProps & EditorContex
         <div className="dark-gray">
           <div className="pl5 mb5">
             <ConditionSection type="scope"
-              shouldEnable={shouldEnableSite}
+              shouldEnableSite={shouldEnableSite}
               conditions={scopeConditions as any}
               activeConditions={[scope]}
               addCondition={setScope as any}

--- a/react/components/conditions/ConditionSelector.tsx
+++ b/react/components/conditions/ConditionSelector.tsx
@@ -45,6 +45,11 @@ class ConditionSelector extends Component<{} & RenderContextProps & EditorContex
   public render() {
     const { editor: { conditions, activeConditions, addCondition, removeCondition, setScope, scope, setDevice, editTreePath }, runtime: { device, page } } = this.props
 
+    const shouldEnableSite = editTreePath && !editTreePath.startsWith(page)
+    if (!shouldEnableSite && scope === 'site') {
+      setScope('url')
+    }
+
     return (
       <div className="near-black">
         <h3 className="bt bw1 b--light-silver pa5 mv0"><FormattedMessage id="pages.editor.conditions.title"/></h3>
@@ -52,7 +57,7 @@ class ConditionSelector extends Component<{} & RenderContextProps & EditorContex
         <div className="dark-gray">
           <div className="pl5 mb5">
             <ConditionSection type="scope"
-              shouldEnable={editTreePath && !editTreePath.startsWith(page)}
+              shouldEnable={shouldEnableSite}
               conditions={scopeConditions as any}
               activeConditions={[scope]}
               addCondition={setScope as any}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -91,7 +91,7 @@ declare global {
 
   type ConfigurationDevice = 'any' | 'desktop' | 'mobile'
 
-  type ConfigurationScope = 'url' | 'route'
+  type ConfigurationScope = 'url' | 'route' | 'site'
 
   interface EditorConditionSection {
     conditions: Condition[] | ConditionsCondition[]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `site` scope option when the component being edited is not defined only to the current page
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Currently, it is not possible to select `site` scope.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
