### PR TITLE
Fix the incorrect type of the min, max and value attributes passed to the Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.12.6] - 2018-07-25
 ### Added
 - Site scope option when the component being edited is not defined only to the current page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Site scope option when the component being edited is not defined only to the current page.
 
+### Fixed
+- Incorrect type of the max, min and value attibutes passed to the `Input`.
+
 ## [1.12.5] - 2018-07-19
 ### Fixed
 - Remove `template` and `site` scope conditions.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "pages-editor",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "title": "VTEX Pages Editor",
   "description": "The VTEX Pages framework editor components",
   "builders": {

--- a/react/components/form/BaseInput.js
+++ b/react/components/form/BaseInput.js
@@ -39,9 +39,9 @@ const BaseInput = props => {
       error={!!currentError}
       errorMessage={currentError}
       helpText={schema.description}
-      label={<FormattedMessage id={label}/>}
-      max={max}
-      min={min}
+      label={<FormattedMessage id={label} />}
+      max={max && `${max}`}
+      min={min && `${min}`}
       onBlur={onBlur && (event => onBlur(id, event.target.value))}
       onChange={_onChange}
       onFocus={onFocus && (event => onFocus(id, event.target.value))}
@@ -49,7 +49,7 @@ const BaseInput = props => {
       readOnly={readonly || schema.readonly}
       required={required}
       type={type}
-      value={value}
+      value={value && `${value}`}
     />
   )
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the incorrect type of the min, max and value attribute passed to the Input, because it was generating some errors in the console. 
![captura de tela de 2018-07-17 11-09-54](https://user-images.githubusercontent.com/12852518/42822703-16c8a99c-89b2-11e8-82b6-0018164dff20.png)

#### How should this be manually tested?
https://waza--storecomponents.myvtex.com/

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
